### PR TITLE
[notify] Have link direct user to deployment homepage

### DIFF
--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: "A JSON payload of key/value pairs for env vars to be set in your container."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.0"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.1"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.0"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.1"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.0"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.1"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.0"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.1"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.0"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.1"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/src/create_or_update_comment.py
+++ b/src/create_or_update_comment.py
@@ -52,7 +52,7 @@ def main():
             comment_to_update = comment
             break
 
-    deployment_url = f"{org_url}/{deployment_name}/"
+    deployment_url = f"{org_url}/{deployment_name}/home"
 
     message = f"[View in Cloud]({deployment_url})"
     image_url = SUCCESS_IMAGE_URL


### PR DESCRIPTION
## Summary

Have the branch deployment link send the user to the `/home` page instead of the root `/` page, which may be the onboarding checklist.

