### PR TITLE
[docs] Add link to quickstart repos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # dagster-cloud-action
 
 [GitHub Actions](https://docs.github.com/en/actions) to deploy code locations to Dagster Cloud.
+
+## Quickstart example repositories
+
+To get started using GitHub Actions-driven CI/CD for Dagster Cloud, take a look at our quickstart example repositories.
+
+- For [Serverless](https://docs.dagster.io/dagster-cloud/deployment/serverless) deployments: [dagster-cloud-serverless-quickstart](https://github.com/dagster-io/dagster-cloud-serverless-quickstart/)
+- For [Hybrid](https://docs.dagster.io/dagster-cloud/deployment/hybrid) deployments: [dagster-cloud-hybrid-quickstart](https://github.com/dagster-io/dagster-cloud-hybrid-quickstart/)


### PR DESCRIPTION
## Summary

Adds a pointer to quickstart repos for both deployment types.