### PR TITLE
[deploy] Skip build+code deploy for closed PRs

### DIFF
--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -44,10 +44,12 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
+      if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/setup-buildx-action@v1
 
     # See https://github.com/docker/build-push-action/ for more info
     - name: Build and push Docker image
+      if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/build-push-action@v3
       with:
         context: ${{ fromJson(inputs.location).directory }}

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -61,9 +61,11 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
+      if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/setup-buildx-action@v1
 
     - name: Copy user code template file
+      if: ${{ github.event.pull_request.state != 'closed' }}
       uses: ./action-repo/actions/utils/copy_template
       with:
         target_directory: ${{ fromJSON(inputs.location).directory }}
@@ -71,6 +73,7 @@ runs:
         base_image: ${{ inputs.base_image }}
 
     - name: Build and push Docker image
+      if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/build-push-action@v3
       with:
         context: ${{ fromJSON(inputs.location).directory }}

--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.6"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.6"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.6"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.6"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.6"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -87,29 +87,31 @@ if [ -z $DEPLOYMENT_NAME ]; then
     exit 1
 fi
 
-echo "Deploying location ${INPUT_LOCATION_NAME} to deployment ${DEPLOYMENT_NAME}..."
+if [ "$INPUT_PR_STATUS" == "open" ]; then
+    echo "Deploying location ${INPUT_LOCATION_NAME} to deployment ${DEPLOYMENT_NAME}..."
 
-echo "::set-output name=deployment::${DEPLOYMENT_NAME}"
+    echo "::set-output name=deployment::${DEPLOYMENT_NAME}"
 
-# Extend timeout in case the agent is still spinning up
-if [ $GITHUB_RUN_NUMBER -eq 1 ]; then
-    AGENT_HEARTBEAT_TIMEOUT=600
-else
-    AGENT_HEARTBEAT_TIMEOUT=90
-fi
+    # Extend timeout in case the agent is still spinning up
+    if [ $GITHUB_RUN_NUMBER -eq 1 ]; then
+        AGENT_HEARTBEAT_TIMEOUT=600
+    else
+        AGENT_HEARTBEAT_TIMEOUT=90
+    fi
 
-dagster-cloud workspace add-location \
-    --url "${DAGSTER_CLOUD_URL}/${DEPLOYMENT_NAME}" \
-    --api-token "$DAGSTER_CLOUD_API_TOKEN" \
-    --location-file "${INPUT_LOCATION_FILE}" \
-    --location-name "${INPUT_LOCATION_NAME}" \
-    --image "${INPUT_REGISTRY}:${INPUT_IMAGE_TAG}" \
-    --location-load-timeout 600 \
-    --agent-heartbeat-timeout $AGENT_HEARTBEAT_TIMEOUT \
-    --git-url $COMMIT_URL \
-    --commit-hash $GITHUB_SHA
+    dagster-cloud workspace add-location \
+        --url "${DAGSTER_CLOUD_URL}/${DEPLOYMENT_NAME}" \
+        --api-token "$DAGSTER_CLOUD_API_TOKEN" \
+        --location-file "${INPUT_LOCATION_FILE}" \
+        --location-name "${INPUT_LOCATION_NAME}" \
+        --image "${INPUT_REGISTRY}:${INPUT_IMAGE_TAG}" \
+        --location-load-timeout 600 \
+        --agent-heartbeat-timeout $AGENT_HEARTBEAT_TIMEOUT \
+        --git-url $COMMIT_URL \
+        --commit-hash $GITHUB_SHA
 
-if [ $? -ne 0 ]; then
-  echo "::error title=Deploy failed::Deploy failed. To view status of your code locations, visit ${DAGSTER_CLOUD_URL}/${DEPLOYMENT_NAME}/workspace"
-  exit 1
+    if [ $? -ne 0 ]; then
+        echo "::error title=Deploy failed::Deploy failed. To view status of your code locations, visit ${DAGSTER_CLOUD_URL}/${DEPLOYMENT_NAME}/workspace"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
## Summary

Skips the image build+push and code location reload  process for PRs that are closed, no reason to redeploy the code in this case.

Still updates branch depl. status.

## Test Plan

Tested on this PR. See e.g. https://github.com/dagster-io/dagster-cloud-action/actions/runs/2967059941