### PR TITLE
fix deploy script for full deployments

### DIFF
--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.8"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.8"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.8"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.8"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.7"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.8"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -87,7 +87,7 @@ if [ -z $DEPLOYMENT_NAME ]; then
     exit 1
 fi
 
-if [ "$INPUT_PR_STATUS" == "open" ]; then
+if [[ -z $INPUT_PR_STATUS || "$INPUT_PR_STATUS" == "open" ]]; then
     echo "Deploying location ${INPUT_LOCATION_NAME} to deployment ${DEPLOYMENT_NAME}..."
 
     echo "::set-output name=deployment::${DEPLOYMENT_NAME}"


### PR DESCRIPTION
Summary:
Path added in https://github.com/dagster-io/dagster-cloud-action/pull/33  didn't account for full deployments, where the PR status is not set.

Test Plan:
(Not sure how to rebuild the util scripts, seems like I need to push a new version?)
Run a full deployment pointed at this new code, branch deployments still update and full deployments now should too.
