### PR TITLE
Checkout github.sha instead of github.head_ref

### DIFF
--- a/.github/workflows/hybrid_branch_deployments.yml
+++ b/.github/workflows/hybrid_branch_deployments.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.sha }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/serverless_branch_custom_base_image.yml
+++ b/.github/workflows/serverless_branch_custom_base_image.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.sha }}
       - name: Build and deploy to Dagster Cloud serverless
         uses: ./actions/serverless_branch_deploy
         with:

--- a/.github/workflows/serverless_branch_deployments.yml
+++ b/.github/workflows/serverless_branch_deployments.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.sha }}
       - name: Build and deploy to Dagster Cloud serverless
         uses: ./actions/serverless_branch_deploy
         with:

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Checkout target repo
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.sha }}
 
     - name: Checkout action repo
       uses: actions/checkout@v3

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Checkout target repo
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.sha }}
 
     - name: Checkout action repo
       uses: actions/checkout@v3

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Checkout target repo
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.sha }}
 
     - name: Checkout action repo
       uses: actions/checkout@v3

--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Checkout target repo
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.sha }}
 
     - name: Checkout action repo
       uses: actions/checkout@v3

--- a/actions/utils/parse_workspace/action.yml
+++ b/actions/utils/parse_workspace/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Checkout target repo
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.sha }}
 
     - id: load_workspace_file
       shell: bash


### PR DESCRIPTION
Because when we merge a branch, github.head_ref might already be deleted if the repo is configured to automatically delete merged branches.

I set up a repo using our template and changed the pin for our actions from `v0.1` to this branch. I was able to successfully merge a PR, see the branch deployment close, and see the code deploy to prod.