### PR TITLE
Add test fixtures for actions and a test for registry_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# Running tests
+
+These unit tests for actions can be run with pytest:
+
+```
+pytest .
+```

--- a/tests/command_stub.py
+++ b/tests/command_stub.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+"""
+Generates a command stub with predefined input and output strings, useful for testing.
+
+To generate a file called some_command:
+
+command_stub.generate('path/to/some_command', {'a': 'A', '-b --c -d=e': 'F'})
+
+To run the generated stub:
+
+$ path/to/some_command a
+A
+$ path/to/some_command -b --c -d=e
+F
+
+Any other invocation of some_command will print an error. Commands are written to 
+path/to/some_command.log.
+
+"""
+
+import json
+import os
+import sys
+from typing import Dict, List, Tuple
+
+
+def normalize_cmdline(args: List[str]) -> Tuple[str]:
+    # could do something better here, to normalize flag order
+    return tuple(arg for arg in args)
+
+
+class CommandHandler:
+    def __init__(self, filepath: str):
+        self.commands = {}
+        self.filepath = filepath
+        self.log_filepath = filepath + ".log"
+        self.cmdname = os.path.basename(filepath)
+
+    def log(self, *msgs):
+        with open(self.log_filepath, "a") as log:
+            log.write(" ".join(msgs))
+            log.write("\n")
+            log.flush()
+
+    def add_command(self, args: List[str], output: str):
+        self.commands[normalize_cmdline(args)] = output
+
+    def feed(self, args: List[str]) -> str:
+        norm_cmdline = normalize_cmdline(args)
+        cmdline = f'{self.cmdname} {" ".join(norm_cmdline)}'
+        if norm_cmdline not in self.commands:
+            self.log("ERROR:", cmdline)
+            raise ValueError(f"Invalid command {cmdline!r}")
+
+        self.log(cmdline)
+        return self.commands[norm_cmdline]
+
+
+commands = {}  # REPLACEMENT_MARKER
+marker = "REPLACEMENT_" + "MARKER"
+
+
+def _replace_line(line, commands_map):
+    if marker in line:
+        # assumme commands_map is just a Dict[str, str], so rendering repr() should work
+        return "commands = " + repr(commands_map)
+    else:
+        return line
+
+
+def generate(out_filepath, commands_map: Dict[str, str]):
+    source = open(__file__).read()
+    if marker not in source:
+        raise ValueError(
+            "generate() called on a generated file, should be called on command_stub"
+        )
+    generated = "\n".join(
+        _replace_line(line, commands_map) for line in source.splitlines()
+    )
+    with open(out_filepath, "w") as out:
+        out.write(generated)
+    os.chmod(out_filepath, 0o775)
+    print("Wrote", out_filepath)
+
+
+if __name__ == "__main__":
+    cmd_handler = CommandHandler(sys.argv[0])
+    for cmd, output in commands.items():
+        if isinstance(cmd, str):
+            args = [arg for arg in cmd.split() if arg]
+        else:
+            args = cmd
+        cmd_handler.add_command(args, output)
+
+    print(cmd_handler.feed(sys.argv[1:]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Dict
+
+import pytest
+
+from . import command_stub
+
+
+class ExecContext:
+    def __init__(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.environ = os.environ.copy()
+        self.add_path(self.temp_dir)
+
+        self.proc = None
+
+    def tmpfile(self, filename):
+        return os.path.join(self.temp_dir, filename)
+
+    def set_env(self, environ: Dict[str, str]):
+        self.environ.update(environ)
+
+    def add_path(self, path):
+        if self.environ.get("PATH"):
+            self.environ["PATH"] = str(path) + ":" + self.environ["PATH"]
+        else:
+            self.environ["PATH"] = str(path)
+
+    def stub_command(self, cmdname, commands_map: Dict[str, str]):
+        """Generate a fake command called cmdname.
+
+        The cmdname accepts cmd line args exactly matching any dictionary key and
+        prints the dictionary value to stdout.
+
+        Eg this creates a fake dagster-cloud command that works for exactly the cmdline specified:
+
+        stub_command(
+            'dagster-cloud',
+            {'serverless registry-info --url "url" --api-token "token"':
+             'AWS_ECR_USERNAME=username\nAWS_ECR_PASSWORD=password\n'})
+        """
+
+        command_stub.generate(self.tmpfile(cmdname), commands_map)
+
+    def run(self, command: str):
+        """Runs command in the exec context"""
+        with open(self.tmpfile("main.sh"), "w") as main_script:
+            main_script.write("#!/bin/bash\n")
+            main_script.write(
+                command
+                + f' > {self.tmpfile("output-stdout.txt")}  2> {self.tmpfile("output-stderr.txt")}\n'
+            )
+            main_script.write(f'echo $? > {self.tmpfile("output-exitcode.txt")}\n')
+            main_script.write(f'env > {self.tmpfile("output-env.txt")}\n')
+        os.chmod(self.tmpfile("main.sh"), 0o700)
+        self.proc = subprocess.run(
+            ["main.sh"], env=self.environ, cwd=self.temp_dir, shell=True
+        )
+
+        exitcode = open(self.tmpfile("output-exitcode.txt")).read().strip()
+        if exitcode != "0":
+            raise ValueError(
+                f"Exit code {exitcode} running {command!r}.\n"
+                f"Stdout: {self.get_stdout()}\nError: {self.get_stderr()}"
+            )
+
+    def get_stdout(self) -> str:
+        return open(self.tmpfile("output-stdout.txt")).read()
+
+    def get_stderr(self) -> str:
+        return open(self.tmpfile("output-stderr.txt")).read()
+
+    def get_output_env(self) -> Dict[str, str]:
+        env = {}
+        for line in open(self.tmpfile("output-env.txt")):
+            try:
+                name, val = line.split("=", 1)
+                env[name] = val.strip()
+            except ValueError:
+                pass
+        return env
+
+    def get_command_log(self, cmdname: str):
+        return open(self.tmpfile(cmdname + ".log")).read().splitlines(keepends=False)
+
+    def cleanup(self):
+        pass
+        # shutil.rmtree(self.temp_dir)
+
+
+@pytest.fixture(scope="function")
+def exec_context():
+    ec = ExecContext()
+    try:
+        yield ec
+    finally:
+        ec.cleanup()
+
+
+@pytest.fixture(scope="session")
+def repo_root():
+    return Path(os.path.abspath(__file__)).parents[1]

--- a/tests/test_registry_info.py
+++ b/tests/test_registry_info.py
@@ -1,0 +1,27 @@
+def test_registry_info(exec_context, repo_root):
+    exec_context.set_env(
+        {
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "GITHUB_ENV": exec_context.tmpfile("github.env"),
+        }
+    )
+
+    exec_context.stub_command(
+        "dagster-cloud",
+        {
+            "serverless registry-info --url http://dagster.cloud/test/prod --api-token api-token": "AWS_ECR_USERNAME=aws-username\nAWS_ECR_PASSWORD=pw\nAWS_DEFAULT_REGION=region\nREGISTRY_URL=http://reg-url\n"
+        },
+    )
+    exec_context.add_path(repo_root / "src")
+    exec_context.run("registry_info.sh")
+    assert "Loaded registry" in exec_context.get_stdout()
+
+    github_env = dict(
+        line.strip().split("=", 1) for line in open(exec_context.tmpfile("github.env"))
+    )
+    assert github_env["AWS_ECR_USERNAME"] == "aws-username"
+    assert github_env["AWS_ECR_PASSWORD"] == "pw"
+    assert github_env["AWS_DEFAULT_REGION"] == "region"
+    assert github_env["REGISTRY_URL"] == "http://reg-url"


### PR DESCRIPTION
Adds a `exec_context` fixture that creates a temp directory to run any bash or python script and lets you set environment variables as well as stub commands which respond to very specific flags (eg `dagster-cloud`). The output environment and generated files can be read from the fixture as well.

This fixture can be used to unit test actions without setting up an actual dagster cloud.

Adds one test for `registry_info.sh`.