### PR TITLE
Bugfix for earlier rename (test -> sample-repo)

### DIFF
--- a/sample-repo/dagster_cloud.yaml
+++ b/sample-repo/dagster_cloud.yaml
@@ -3,5 +3,5 @@ locations:
     code_source:
       python_file: repo.py
     build:
-      directory: ./test
+      directory: ./sample-repo
       registry: 764506304434.dkr.ecr.us-west-2.amazonaws.com/branch-deployments-gh-action-test


### PR DESCRIPTION
Missed one reference to the moved ./test directory