### PR TITLE
Use an image tag that matches the dagster version and python version packaged in the deps.pex

### DIFF
--- a/actions/build_deploy_pex/action.yml
+++ b/actions/build_deploy_pex/action.yml
@@ -24,7 +24,8 @@ runs:
     - name: Checkout action repo
       uses: actions/checkout@v3
       with:
-        repository: dagster-io/dagster-cloud-action
+        # TODO: remove branch indicator before merge
+        repository: dagster-io/dagster-cloud-action@shalabhc/peg-image-tag-to-dagster-version
         path: $GITHUB_WORKSPACE/action-repo
 
     - name: Set up Python 3.8

--- a/actions/build_deploy_pex/action.yml
+++ b/actions/build_deploy_pex/action.yml
@@ -24,8 +24,9 @@ runs:
     - name: Checkout action repo
       uses: actions/checkout@v3
       with:
-        # TODO: remove branch indicator before merge
-        repository: dagster-io/dagster-cloud-action@shalabhc/peg-image-tag-to-dagster-version
+        repository: dagster-io/dagster-cloud-action
+        # TODO: remove ref indicator before merge
+        ref: 'shalabhc/peg-image-tag-to-dagster-version'
         path: $GITHUB_WORKSPACE/action-repo
 
     - name: Set up Python 3.8

--- a/src/pex-builder/builder/deploy.py
+++ b/src/pex-builder/builder/deploy.py
@@ -142,12 +142,9 @@ def build_locations(
     return location_builds
 
 
-DEFAULT_BASE_IMAGE_PREFIX = "ghcr.io/dagster-io/dagster-cloud-serverless-base-py38:"
-
-
 def get_base_image_for(dagster_version: str):
     # TODO: verify this image exists in the registry
-    return DEFAULT_BASE_IMAGE_PREFIX + dagster_version
+    return f"ghcr.io/dagster-io/dagster-cloud-serverless-base-py38:{dagster_version}"
 
 
 @click.command()

--- a/src/pex-builder/builder/deploy.py
+++ b/src/pex-builder/builder/deploy.py
@@ -29,10 +29,8 @@ class LocationBuild:
     # One of deps_pex_path or published_deps_pex should be set
     deps_pex_path: Optional[str] = None  # locally build deps.pex
     published_deps_pex: Optional[str] = None  # already published deps.pex
-    dagster_version: Optional[
-        str
-    ] = None  # set for both, already published and locally built deps
-
+    # dagster_version should be alway set for both cases, pre published and locally built deps
+    dagster_version: Optional[str] = None
     source_pex_path: Optional[str] = None
     pex_tag: Optional[str] = None  # composite tag used to identify the set of pex files
 

--- a/src/pex-builder/builder/pex_registry.py
+++ b/src/pex-builder/builder/pex_registry.py
@@ -58,7 +58,10 @@ def requirements_hash_filename(requirements_hash: str):
 def get_requirements_hash_values(
     requirements_hash: str,
 ) -> Optional[Dict[str, Any]]:
-    """Returns the 'deps-<HASH>.pex' filename and other details for requirements_hash if already uploaded."""
+    """Returns a metadata dict for the requirements_hash. The dict contains:
+    'deps_pex_name': filename for the deps pex, eg 'deps-123234334.pex'
+    'dagster_version': dagster package version included in the deps, eg '1.0.14'
+    """
     urls = get_s3_urls_for_get([requirements_hash_filename(requirements_hash)])
     if not urls:
         return None
@@ -70,6 +73,7 @@ def get_requirements_hash_values(
     result = requests.get(url)
     if result.ok:
         data = json.loads(result.content)
+        # Don't return partial information
         if "deps_pex_name" in data and "dagster_version" in data:
             return data
     return None

--- a/src/pex-builder/builder/pex_registry.py
+++ b/src/pex-builder/builder/pex_registry.py
@@ -1,9 +1,8 @@
 import json
 import logging
 import os
-import sys
 from tempfile import TemporaryDirectory
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -56,10 +55,10 @@ def requirements_hash_filename(requirements_hash: str):
     return f"requirements-{requirements_hash}.txt"
 
 
-def get_deps_pex_name_from_requirements_hash(
+def get_requirements_hash_values(
     requirements_hash: str,
-) -> Optional[str]:
-    """Returns the 'deps-<HASH>.pex' filename for requirements_hash if already uploaded."""
+) -> Optional[Dict[str, Any]]:
+    """Returns the 'deps-<HASH>.pex' filename and other details for requirements_hash if already uploaded."""
     urls = get_s3_urls_for_get([requirements_hash_filename(requirements_hash)])
     if not urls:
         return None
@@ -71,14 +70,19 @@ def get_deps_pex_name_from_requirements_hash(
     result = requests.get(url)
     if result.ok:
         data = json.loads(result.content)
-        return data["deps_pex_name"]
+        if "deps_pex_name" in data and "dagster_version" in data:
+            return data
     return None
 
 
-def set_requirements_hash_values(requirements_hash: str, deps_pex_name: str):
-    """Saves the deps_pex_name into the requirements hash file."""
+def set_requirements_hash_values(
+    requirements_hash: str, deps_pex_name: str, dagster_version: str
+):
+    """Saves the deps_pex_name and dagster_version into the requirements hash file."""
     filename = requirements_hash_filename(requirements_hash)
-    content = json.dumps({"deps_pex_name": deps_pex_name})
+    content = json.dumps(
+        {"deps_pex_name": deps_pex_name, "dagster_version": dagster_version}
+    )
     with TemporaryDirectory() as tmp_dir:
         filepath = os.path.join(tmp_dir, filename)
         with open(filepath, "w") as f:


### PR DESCRIPTION
This ensures the dagster libraries installed in the docker image are identical to the ones shipped in the deps.pex. It also selects an image matching the python version used in user code.

The plan is to build and publish base images for different python versions and dagster versions.