### PR TITLE
Add support for SERVERLESS_BASE_IMAGE_TAG

### DIFF
--- a/src/pex-builder/builder/deploy.py
+++ b/src/pex-builder/builder/deploy.py
@@ -156,10 +156,19 @@ def build_locations(
 
 
 def get_base_image_for(location_build: LocationBuild) -> str:
+    # Full path to base image is supplied
     base_image = os.getenv("SERVERLESS_BASE_IMAGE")
     if base_image:
         return base_image
 
+    # Tag suffix for base image is supplied - uses custom uploaded image
+    base_image_tag = os.getenv("SERVERLESS_BASE_IMAGE_TAG")
+    if base_image_tag:
+        # Point to user's registry info with this tag suffix
+        registry_info = util.get_registry_info()
+        return f"{registry_info['registry_url']}:{base_image_tag}"
+
+    # Use the default base image in dagster cloud
     # TODO: Read from cloud API or another config?
     registry_subdomain = (
         "878483074102" if ".dogfood." in os.getenv("DAGSTER_CLOUD_URL", "") else "657821118200"

--- a/src/pex-builder/builder/util.py
+++ b/src/pex-builder/builder/util.py
@@ -129,6 +129,11 @@ def graphql_client(deployment_name: str):
         yield client
 
 
+def get_registry_info():
+    with graphql_client("prod") as client:
+        return gql.get_ecr_info(client)
+
+
 def url_for_deployment(deployment_name):
     dagster_cloud_url = os.getenv("DAGSTER_CLOUD_URL")
     if not dagster_cloud_url:


### PR DESCRIPTION
Allows setting the base image using the published tag only.

Ports https://github.com/dagster-io/internal/pull/4283 to the action repo.