### PR TITLE
Add python_file support to builder.pex

### DIFF
--- a/src/pex-builder/builder/deps.py
+++ b/src/pex-builder/builder/deps.py
@@ -132,7 +132,7 @@ def get_requirements_txt_deps(code_directory: str) -> List[str]:
 def get_setup_py_deps(code_directory: str) -> List[str]:
     setup_py_path = os.path.join(code_directory, "setup.py")
     if not os.path.exists(setup_py_path):
-        raise ValueError("setup.py not found", setup_py_path)
+        return []
 
     lines = []
     # write out egg_info files and load as distribution

--- a/src/pex-builder/builder/parse_workspace.py
+++ b/src/pex-builder/builder/parse_workspace.py
@@ -27,12 +27,6 @@ def get_locations(dagster_cloud_yaml_file) -> List[Location]:
             location_dir = os.path.join(
                 base_dir, location.get("build", {"directory": "."}).get("directory")
             )
-            python_file = location.get("code_source", {}).get("python_file")
-            if python_file:
-                raise ValueError(
-                    f"code_source.python_file {python_file!r} is not supported for Serverless fast deploys. "
-                    "Please use code_source.package_name, or set ENABLE_FAST_DEPLOYS to false."
-                )
             locations.append(
                 Location(
                     name=location["location_name"],

--- a/src/pex-builder/builder/source.py
+++ b/src/pex-builder/builder/source.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import os.path
+import shutil
 import subprocess
 import tempfile
 from uuid import uuid4
@@ -31,32 +32,59 @@ def build_source_pex(code_directory, output_directory, python_version):
 
 def build_pex_using_setup_py(code_directory, tmp_pex_path, python_version):
     "Builds package using setup.py and copies built output into PEX."
-    python_interpreter = util.python_interpreter_for(python_version)
-    logging.info(f"Building packages using {python_interpreter} setup.py build")
+
     curdir = os.curdir
     os.chdir(code_directory)
-    if not os.path.exists("setup.py"):
-        raise ValueError(f"setup.py not found in {code_directory!r}")
     try:
-        with tempfile.TemporaryDirectory() as build_dir:
-            # build setup.py with the python version specified
-            command = [
-                python_interpreter,
-                "setup.py",
-                "build",
-                "--build-lib",
-                build_dir,
-            ]
-            subprocess.run(command, capture_output=True, check=True)
+        with tempfile.TemporaryDirectory() as build_dir, tempfile.TemporaryDirectory() as sources_dir:
+            included_dirs = []
+
+            if os.path.exists("setup.py"):
+                python_interpreter = util.python_interpreter_for(python_version)
+                logging.info(f"Building packages using {python_interpreter} setup.py build")
+
+                # build setup.py with the python version specified
+                command = [
+                    python_interpreter,
+                    "setup.py",
+                    "build",
+                    "--build-lib",
+                    build_dir,
+                ]
+                subprocess.run(command, capture_output=True, check=True)
+                included_dirs.append(build_dir)
+            else:
+                logging.info(f"No setup.py found in {code_directory!r}, will only include source.")
+
+            # We always include the source in a special package called working_directory.
+            logging.info(
+                "Bunding the source %r into the 'working_directory' package", code_directory
+            )
+            _prepare_working_directory(code_directory, sources_dir)
+            included_dirs.append(sources_dir)
+
             # note this may include tests directories
             util.build_pex(
-                [build_dir],
+                included_dirs,
                 requirements_filepaths=[],
                 pex_flags=util.get_pex_flags(python_version),
                 output_pex_path=tmp_pex_path,
             )
     finally:
         os.chdir(curdir)
+
+
+def _prepare_working_directory(code_directory, sources_directory):
+    # Copy code_directory contents into a package called working_directory under sources_directory
+    package_dir = os.path.join(sources_directory, "working_directory")
+    os.makedirs(package_dir, exist_ok=True)
+
+    with open(os.path.join(package_dir, "__init__.py"), "w", encoding="utf-8") as init_file:
+        init_file.write("# Auto generated package containing the original source at root/")
+
+    shutil.copytree(
+        code_directory, os.path.join(package_dir, "root"), copy_function=os.link, dirs_exist_ok=True
+    )
 
 
 @click.command()

--- a/tests/test-repos/dagster_project_python_file/repository.py
+++ b/tests/test-repos/dagster_project_python_file/repository.py
@@ -1,0 +1,1 @@
+# dagster_project_python_file

--- a/tests/test-repos/dagster_project_python_file/requirements.txt
+++ b/tests/test-repos/dagster_project_python_file/requirements.txt
@@ -1,0 +1,2 @@
+dagster
+dagster-cloud[serverless]

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -68,16 +68,15 @@ def test_pex_deploy_build_only(repo_root, builder_pex_path):
         assert "RUN_SUCCESS" in output
 
 
-def test_pex_deploy_python_file_error(repo_root, builder_pex_path):
+def test_pex_deploy_python_file(repo_root, builder_pex_path):
     dagster_project_yaml = (
         repo_root / "tests/test-repos/dagster_project_python_file/dagster_cloud.yaml"
     )
-    with pytest.raises(ValueError) as build_err:
-        with run_builder(
-            builder_pex_path, ["-m", "builder.deploy", str(dagster_project_yaml)]
-        ) as _:
-            pass
-    assert build_err.match("code_source.python_file")
+    with run_builder(
+        builder_pex_path, ["-m", "builder.deploy", str(dagster_project_yaml)]
+    ) as _:
+        # just make sure the build worked
+        pass
 
 
 def test_pex_deps_build(repo_root, builder_pex_path):

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -74,9 +74,29 @@ def test_pex_deploy_python_file(repo_root, builder_pex_path):
     )
     with run_builder(
         builder_pex_path, ["-m", "builder.deploy", str(dagster_project_yaml)]
-    ) as _:
-        # just make sure the build worked
-        pass
+    ) as (build_output_dir, pex_files, other_files):
+        pex_file_by_alias = {
+            filename.split("-", 1)[0]: filename for filename in pex_files
+        }
+
+        # make sure the working_directory was included with the file
+        output = subprocess.check_output(
+            [
+                "./" + pex_file_by_alias["source"],
+                "-c",
+                "import working_directory; print(working_directory.__file__);",
+            ],
+            env={**os.environ, "PEX_PATH": pex_file_by_alias["deps"]},
+            cwd=build_output_dir,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
+        )
+
+        assert "working_directory" in output
+        repo_contents = open(
+            output.strip().replace("__init__.py", "root/repository.py")
+        ).read()
+        assert "dagster_project_python_file" in repo_contents
 
 
 def test_pex_deps_build(repo_root, builder_pex_path):


### PR DESCRIPTION
Add `python_file` support by packaging the source directory in a `working_directory` package.
This PR ports a recent change in the dagster-cloud CLI to builder.pex.