### PR TITLE
Ignore .git and a few other files when copying the working directory

### DIFF
--- a/src/pex-builder/builder/source.py
+++ b/src/pex-builder/builder/source.py
@@ -13,6 +13,7 @@ import click
 from . import util
 
 # inspired by https://github.com/github/gitignore/blob/main/Python.gitignore
+# would be nice to just read the gitignore and use that
 IGNORED_PATTERNS = [".git", "__pycache__", ".pytest_cache", ".tox", ".nox", "*.pyc", ".mypy_cache"]
 
 

--- a/src/pex-builder/builder/source.py
+++ b/src/pex-builder/builder/source.py
@@ -12,6 +12,9 @@ import click
 
 from . import util
 
+# inspired by https://github.com/github/gitignore/blob/main/Python.gitignore
+IGNORED_PATTERNS = [".git", "__pycache__", ".pytest_cache", ".tox", ".nox", "*.pyc", ".mypy_cache"]
+
 
 def build_source_pex(code_directory, output_directory, python_version):
     output_directory = os.path.abspath(output_directory)
@@ -87,7 +90,7 @@ def _prepare_working_directory(code_directory, sources_directory):
         os.path.join(package_dir, "root"),
         copy_function=os.link,
         dirs_exist_ok=True,
-        ignore=shutil.ignore_patterns(".git"),
+        ignore=shutil.ignore_patterns(*IGNORED_PATTERNS),
     )
 
 

--- a/src/pex-builder/builder/source.py
+++ b/src/pex-builder/builder/source.py
@@ -83,7 +83,11 @@ def _prepare_working_directory(code_directory, sources_directory):
         init_file.write("# Auto generated package containing the original source at root/")
 
     shutil.copytree(
-        code_directory, os.path.join(package_dir, "root"), copy_function=os.link, dirs_exist_ok=True
+        code_directory,
+        os.path.join(package_dir, "root"),
+        copy_function=os.link,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns(".git"),
     )
 
 


### PR DESCRIPTION
For supporting `python_file`, we copy the working directory into the pex file. However we probably don't want `.git` and other special directories and files.