### PR TITLE
Try to build deps.pex using different sets of flags.

### DIFF
--- a/src/pex-builder/builder/source.py
+++ b/src/pex-builder/builder/source.py
@@ -89,7 +89,6 @@ def _prepare_working_directory(code_directory, sources_directory):
     shutil.copytree(
         code_directory,
         os.path.join(package_dir, "root"),
-        copy_function=os.link,
         dirs_exist_ok=True,
         ignore=shutil.ignore_patterns(*IGNORED_PATTERNS),
     )


### PR DESCRIPTION
This PR allows multiple alternative way to build `deps.pex` and uses the first one that works. This also allows adding new flags safely in the future. Based on a flag suggsted by the pants/pex team.

## Test

This fixes multiple recent user reported issues. After I reproduced one issue, using the new code is able to build the dependencies with this log, which shows the retry with the new flag:

```
  INFO:root:Building deps pex for Python version <Version('3.8')>
  INFO:root:Running pex with '--python=python3.8 --platform=manylinux2014_x86_64-cp-38-cp38 --resolve-local-platforms --no-strip-pex-env --pip-version=22.2.2'
  INFO:root:Running ['/home/runner/work/_actions/dagster-io/dagster-cloud-action/shalabhc/improve-dependency-resolution/generated/gha/builder.pex', '-m', 'pex', '--python=python3.8', '--platform=manylinux2014_x86_64-cp-38-cp38', '--resolve-local-platforms', '--no-strip-pex-env', '--pip-version=22.2.2', '-r', '/home/runner/work/demo-1/demo-1/build/deps-requirements-d153b7b2ed0ebb12fedd0eb9fd1aadb829e25c66.txt', '-o', '/home/runner/work/demo-1/demo-1/build/deps-from-d153b7b2ed0ebb12fedd0eb9fd1aadb829e25c66.pex', '--pex-root', '/home/runner/work/demo-1/demo-1/build/.pex'] in '/home/runner/work/_actions/dagster-io/dagster-cloud-action/shalabhc/improve-dependency-resolution'
  WARNING:root:Failed to resolve compatible distributions:
  1: dbt-snowflake==1.3.0 requires snowflake-connector-python[secure-local-storage]<2.8.0,>=2.4.1 but snowflake-connector-python 2.8.3 was resolved
  2: pyOpenSSL==22.1.0 requires cryptography<39,>=38.0.0 but cryptography 36.0.2 was resolved
  
  WARNING:root:Will retry building deps with a different resolution mechanism
  INFO:root:Running pex with '--python=python3.8 --platform=manylinux2014_x86_64-cp-38-cp38 --resolve-local-platforms --no-strip-pex-env --pip-version=22.2.2 --resolver-version=pip-2020-resolver'
  INFO:root:Running ['/home/runner/work/_actions/dagster-io/dagster-cloud-action/shalabhc/improve-dependency-resolution/generated/gha/builder.pex', '-m', 'pex', '--python=python3.8', '--platform=manylinux2014_x86_64-cp-38-cp38', '--resolve-local-platforms', '--no-strip-pex-env', '--pip-version=22.2.2', '--resolver-version=pip-2020-resolver', '-r', '/home/runner/work/demo-1/demo-1/build/deps-requirements-d153b7b2ed0ebb12fedd0eb9fd1aadb829e25c66.txt', '-o', '/home/runner/work/demo-1/demo-1/build/deps-from-d153b7b2ed0ebb12fedd0eb9fd1aadb829e25c66.pex', '--pex-root', '/home/runner/work/demo-1/demo-1/build/.pex'] in '/home/runner/work/_actions/dagster-io/dagster-cloud-action/shalabhc/improve-dependency-resolution'
  INFO:root:Wrote deps pex: '/home/runner/work/demo-1/demo-1/build/deps-6d7e15fa3b8aceb58decbf2af899c93b03756da1.pex'```