### PR TITLE
Extract parse_workspace.py

### DIFF
--- a/actions/utils/parse_workspace/action.yml
+++ b/actions/utils/parse_workspace/action.yml
@@ -21,4 +21,4 @@ runs:
 
     - id: load_workspace_file
       shell: bash
-      run: "python /parse_workspace.py ${{ inputs.dagster_cloud_file }}"
+      run: "python $GITHUB_ACTION_PATH/../../../src/parse_workspace.py ${{ inputs.dagster_cloud_file }}"

--- a/actions/utils/parse_workspace/action.yml
+++ b/actions/utils/parse_workspace/action.yml
@@ -21,28 +21,4 @@ runs:
 
     - id: load_workspace_file
       shell: bash
-      run: |
-        python -c "
-        import yaml, json
-        import os
-
-        workspace = '${{ inputs.dagster_cloud_file }}'
-        secrets_set = bool(os.getenv('DAGSTER_CLOUD_API_TOKEN'))
-
-        with open(workspace) as f:
-            workspace_contents = f.read()
-        workspace_contents_yaml = yaml.safe_load(workspace_contents)
-
-        output_obj = [
-            {
-                'name': location['location_name'],
-                'directory': location.get('build', {'directory': '.'}).get('directory'),
-                'build_folder': location.get('build', {'directory': '.'}).get('directory'),
-                'registry': location.get('build', {'directory': '.'}).get('registry'),
-                'location_file': str(workspace),
-            }
-            for location in workspace_contents_yaml['locations']
-        ]
-        print(f'::set-output name=build_info::{json.dumps(output_obj)}')
-        print(f'::set-output name=secrets_set::{json.dumps(secrets_set)}')
-        "
+      run: "python /parse_workspace.py ${{ inputs.dagster_cloud_file }}"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -19,6 +19,7 @@ COPY expand_env_vars.py /expand_env_vars.py
 COPY create_or_update_comment.py /create_or_update_comment.py
 COPY expand_json_env.py /expand_json_env.py
 COPY fetch_github_avatar.py /fetch_github_avatar.py
+COPY parse_workspace.py parse_workspace.py
 
 
 COPY notify.sh /notify.sh

--- a/src/parse_workspace.py
+++ b/src/parse_workspace.py
@@ -1,0 +1,31 @@
+import sys
+import yaml
+import json
+import os
+
+
+def parse_workspace(dagster_cloud_file):
+    workspace = dagster_cloud_file
+    secrets_set = bool(os.getenv("DAGSTER_CLOUD_API_TOKEN"))
+
+    with open(workspace) as f:
+        workspace_contents = f.read()
+    workspace_contents_yaml = yaml.safe_load(workspace_contents)
+
+    output_obj = [
+        {
+            "name": location["location_name"],
+            "directory": location.get("build", {"directory": "."}).get("directory"),
+            "build_folder": location.get("build", {"directory": "."}).get("directory"),
+            "registry": location.get("build", {"directory": "."}).get("registry"),
+            "location_file": str(workspace),
+        }
+        for location in workspace_contents_yaml["locations"]
+    ]
+    print(f"::set-output name=build_info::{json.dumps(output_obj)}")
+    print(f"::set-output name=secrets_set::{json.dumps(secrets_set)}")
+
+
+if __name__ == "__main__":
+    dagster_cloud_yaml_file = sys.argv[1]
+    parse_workspace(dagster_cloud_yaml_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,7 @@ from . import command_stub
 class ExecContext:
     def __init__(self, tmp_dir):
         self.tmp_dir = tmp_dir
-        self.environ = {}
-        self.proc = None
+        self.reset()
 
     def tmp_file_path(self, filename) -> Path:
         "Return a Path object pointing to named file in tmp_dir."
@@ -146,6 +145,10 @@ class ExecContext:
 
     def get_command_log(self, cmdname: str):
         return self.tmp_file_content(cmdname + ".log").splitlines(keepends=False)
+
+    def reset(self):
+        self.environ = {}
+        self.proc = None
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,14 @@ class ExecContext:
 
         script_path = self.prepare_run_script(command)
         print("Running:", script_path)
-        self.proc = subprocess.run([script_path], shell=True, check=True)
+        self.proc = subprocess.run(
+            [script_path],
+            shell=True,
+            check=True,
+            env={
+                "PATH": os.getenv("PATH"),
+            },
+        )
         self.post_run(command)
 
     def run_docker_command(self, docker_image_tag, command):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ from . import command_stub
 
 
 class ExecContext:
-    def __init__(self):
-        self.tmp_dir = tempfile.mkdtemp()
+    def __init__(self, tmp_dir):
+        self.tmp_dir = tmp_dir
         self.environ = {}
         self.proc = None
 
@@ -147,17 +147,10 @@ class ExecContext:
     def get_command_log(self, cmdname: str):
         return self.tmp_file_content(cmdname + ".log").splitlines(keepends=False)
 
-    def cleanup(self):
-        shutil.rmtree(self.tmp_dir)
-
 
 @pytest.fixture(scope="function")
-def exec_context():
-    ec = ExecContext()
-    try:
-        yield ec
-    finally:
-        ec.cleanup()
+def exec_context(tmp_path):
+    yield ExecContext(tmp_dir=tmp_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_parse_workspace.py
+++ b/tests/test_parse_workspace.py
@@ -1,0 +1,48 @@
+import yaml
+import json
+import os
+
+
+def test_parse_workspace(repo_root, exec_context, tmp_path):
+    dagster_cloud_file = tmp_path / "dagster_cloud.yaml"
+    workspace = {
+        "locations": [
+            {
+                "location_name": "foo",
+                "code_source": {
+                    "python_file": "repo.py",
+                },
+                "build": {
+                    "directory": ".",
+                    "registry": "some-registry",
+                },
+            }
+        ]
+    }
+    dagster_cloud_file.write_text(yaml.dump(workspace))
+
+    command = f"python {repo_root}/src/parse_workspace.py {dagster_cloud_file}"
+    exec_context.run_local_command(command)
+
+    # build_info
+    expected = [
+        {
+            "name": "foo",
+            "directory": ".",
+            "build_folder": ".",
+            "registry": "some-registry",
+            "location_file": str(dagster_cloud_file),
+        }
+    ]
+    assert (
+        f"::set-output name=build_info::{json.dumps(expected)}"
+        in exec_context.get_stdout()
+    )
+
+    # secrets_set
+    assert "::set-output name=secrets_set::false" in exec_context.get_stdout()
+
+    exec_context.reset()
+    exec_context.set_env({"DAGSTER_CLOUD_API_TOKEN": "true"})
+    exec_context.run_local_command(command)
+    assert "::set-output name=secrets_set::true" in exec_context.get_stdout()


### PR DESCRIPTION
The behavior itself will need to change for a few reasons:

1. Github is retiring set-output
2. We'll need to generalize it for other CI providers
3. It's not immediately clear to me if/how we use secrets_set so we
   might not need it anymore.

But this adds some minimal unit testing of existing behavior and swaps
out our in-line python string with an actual python script.