### PR TITLE
Migrate from set-output to $GITHUB_OUTPUTS

### DIFF
--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -41,5 +41,7 @@ runs:
   using: "docker"
   image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.10"
   entrypoint: "/deploy.sh"
+  env:
+    OUTPUT_FILE: $GITHUB_OUTPUT
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/parse_workspace/action.yml
+++ b/actions/utils/parse_workspace/action.yml
@@ -21,4 +21,4 @@ runs:
 
     - id: load_workspace_file
       shell: bash
-      run: "python $GITHUB_ACTION_PATH/../../../src/parse_workspace.py ${{ inputs.dagster_cloud_file }}"
+      run: "python $GITHUB_ACTION_PATH/../../../src/parse_workspace.py ${{ inputs.dagster_cloud_file }} >> $GITHUB_OUTPUT"

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -109,8 +109,7 @@ fi
 
 if [[ -z $PR_STATUS || "$PR_STATUS" == "OPEN" ]]; then
     echo "Deploying location ${INPUT_LOCATION_NAME} to deployment ${DEPLOYMENT_NAME}..."
-
-    echo "::set-output name=deployment::${DEPLOYMENT_NAME}"
+    echo "deployment=${DEPLOYMENT_NAME}" >> ${OUTPUT_FILE}
 
     # Extend timeout in case the agent is still spinning up
     if [[ $CI_RUN_NUMBER -eq 1 ]]; then

--- a/src/parse_workspace.py
+++ b/src/parse_workspace.py
@@ -22,8 +22,8 @@ def parse_workspace(dagster_cloud_file):
         }
         for location in workspace_contents_yaml["locations"]
     ]
-    print(f"::set-output name=build_info::{json.dumps(output_obj)}")
-    print(f"::set-output name=secrets_set::{json.dumps(secrets_set)}")
+    print(f"build_info={json.dumps(output_obj)}")
+    print(f"secrets_set={json.dumps(secrets_set)}")
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -2,7 +2,10 @@ import pytest
 import json
 
 
-def test_deploy_full_deployment_github(exec_context, action_docker_image_id):
+def test_deploy_full_deployment_github(tmp_path, exec_context, action_docker_image_id):
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
+
     exec_context.set_env(
         {
             "GITHUB_ACTIONS": "true",
@@ -21,6 +24,7 @@ def test_deploy_full_deployment_github(exec_context, action_docker_image_id):
             "GITHUB_REPOSITORY": "some-org/some-project",
             "GITHUB_SHA": "sha12345",
             "INPUT_IMAGE_TAG": "prod-some-location-sha",
+            "OUTPUT_FILE": output_file.name,
         }
     )
 
@@ -37,9 +41,13 @@ def test_deploy_full_deployment_github(exec_context, action_docker_image_id):
     )
     exec_context.run_docker_command(action_docker_image_id, "/deploy.sh")
     assert "Deploying location some-location" in exec_context.get_stdout()
+    assert "deployment=prod" in output_file.read_text()
 
 
-def test_deploy_full_deployment_gitlab(exec_context, action_docker_image_id):
+def test_deploy_full_deployment_gitlab(exec_context, action_docker_image_id, tmp_path):
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
+
     exec_context.set_env(
         {
             "GITLAB_CI": "true",
@@ -57,6 +65,7 @@ def test_deploy_full_deployment_gitlab(exec_context, action_docker_image_id):
             "CI_PROJECT_URL": "https://gitlab.com/some-org/some-project/",
             "CI_COMMIT_SHORT_SHA": "sha12345",
             "INPUT_IMAGE_TAG": "prod-some-location-sha",
+            "OUTPUT_FILE": output_file.name,
         }
     )
 
@@ -73,6 +82,7 @@ def test_deploy_full_deployment_gitlab(exec_context, action_docker_image_id):
     )
     exec_context.run_docker_command(action_docker_image_id, "/deploy.sh")
     assert "Deploying location some-location" in exec_context.get_stdout()
+    assert "deployment=prod" in output_file.read_text()
 
 
 def test_deploy_full_deployment_unsupported_ci(exec_context, action_docker_image_id):

--- a/tests/test_parse_workspace.py
+++ b/tests/test_parse_workspace.py
@@ -35,14 +35,14 @@ def test_parse_workspace(repo_root, exec_context, tmp_path):
         }
     ]
     assert (
-        f"::set-output name=build_info::{json.dumps(expected)}"
+        f"build_info={json.dumps(expected)}"
         in exec_context.get_stdout()
     )
 
     # secrets_set
-    assert "::set-output name=secrets_set::false" in exec_context.get_stdout()
+    assert "secrets_set=false" in exec_context.get_stdout()
 
     exec_context.reset()
     exec_context.set_env({"DAGSTER_CLOUD_API_TOKEN": "true"})
     exec_context.run_local_command(command)
-    assert "::set-output name=secrets_set::true" in exec_context.get_stdout()
+    assert "secrets_set=true" in exec_context.get_stdout()


### PR DESCRIPTION
This will squash the deprecation warning that we see every time the action runs.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs

Incidentally, it also conforms to how Gitlab will expect us to pass variables from job to job:

https://docs.gitlab.com/ee/ci/variables/#pass-an-environment-variable-to-another-job