### PR TITLE
Fix breakage due to code deletion

### DIFF
--- a/src/pex-builder/builder/__init__.py
+++ b/src/pex-builder/builder/__init__.py
@@ -1,1 +1,1 @@
-from . import deploy, deps, parse_workspace, pex_registry, source, util
+from . import deploy

--- a/src/pex-builder/builder/selftest.py
+++ b/src/pex-builder/builder/selftest.py
@@ -4,7 +4,7 @@ import os
 import pprint
 import sys
 
-from . import util
+from dagster_cloud_cli.core.pex_builder import util
 
 if __name__ == "__main__":
     print("hello from selftest.py")

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -331,3 +331,10 @@ def test_builder_deploy_with_upload(
         print(pex_registry_fixture)
         assert "deps-pex-7.pex" not in pex_registry_fixture
         assert location_builds[0].pex_tag == "files=deps-pex-5.pex:source-pex-1.pex"
+
+
+def test_builder_selftest(builder_pex_path):
+    output = subprocess.check_output(
+        [builder_pex_path, "-m", "builder.selftest"], encoding="utf-8"
+    )
+    assert "hello from selftest.py" in output


### PR DESCRIPTION
Follow up to https://github.com/dagster-io/dagster-cloud-action/pull/75 which broke the builder selftest.

The selftest was not part of the test suite also added now.