### PR TITLE
add flag to disable inner repo checkout

### DIFF
--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout target repo
-      if: ${{ inputs.checkout_repo }} == 'true'
+      if: inputs.checkout_repo == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -10,11 +10,16 @@ inputs:
   location:
     required: true
     description: 'The code location to deploy. A JSON string consisting of keys "name", "directory", "registry", "location_file".'
+  checkout_repo:
+    required: false
+    description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
+    default: 'true'
   # Build, push, deploy each location
 runs:
   using: "composite"
   steps:
     - name: Checkout target repo
+      if: ${{ inputs.checkout_repo }} == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout target repo
-      if: ${{ inputs.checkout_repo }} == 'true'
+      if: inputs.checkout_repo == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -15,10 +15,16 @@ inputs:
     required: false
     description: "The deployment to push to, defaults to 'prod'."
     default: "prod"
+  checkout_repo:
+    required: false
+    description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
+    default: 'true'
+
 runs:
   using: "composite"
   steps:
     - name: Checkout target repo
+      if: ${{ inputs.checkout_repo }} == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -16,10 +16,15 @@ inputs:
   base_image:
     required: false
     description: "A string of the base image name for the deployed code location image."
+  checkout_repo:
+    required: false
+    description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
+    default: 'true'
 runs:
   using: "composite"
   steps:
     - name: Checkout target repo
+      if: ${{ inputs.checkout_repo }} == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout target repo
-      if: ${{ inputs.checkout_repo }} == 'true'
+      if:  inputs.checkout_repo == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout target repo
-      if: ${{ inputs.checkout_repo } == 'true'
+      if: inputs.checkout_repo == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -20,10 +20,16 @@ inputs:
     required: false
     description: "The deployment to push to, defaults to 'prod'."
     default: "prod"
+  checkout_repo:
+    required: false
+    description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
+    default: 'true'
+
 runs:
   using: "composite"
   steps:
     - name: Checkout target repo
+      if: ${{ inputs.checkout_repo } == 'true'
       uses: actions/checkout@v3
       with:
         ref: ${{ github.sha }}

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -16,6 +16,10 @@ RUN if [ -f "setup.py" ]; then \
 WORKDIR /opt/dagster/app
 COPY . /opt/dagster/app
 
+RUN apt-get install tree 
+
+RUN tree -L 2 ./
+
 # Install the rest of dependencies in case there is a requirements.txt
 RUN if [ -f "requirements.txt" ]; then \
         pip install -r requirements.txt; \

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -16,10 +16,6 @@ RUN if [ -f "setup.py" ]; then \
 WORKDIR /opt/dagster/app
 COPY . /opt/dagster/app
 
-RUN apt-get install tree 
-
-RUN tree -L 2 ./
-
 # Install the rest of dependencies in case there is a requirements.txt
 RUN if [ -f "requirements.txt" ]; then \
         pip install -r requirements.txt; \


### PR DESCRIPTION
Currently the Github actions checkout the target repo twice, once in the default workflows we provide as templates, and again inside the deploy actions.

The second checkout makes it hard for teams who want to use actions to customize the file structure prior to deployment. One common use case is copying a parent utilities folder into the dagster project's build directory.

This PR adds a flag that does not change the default behavior but allows users to disable the second checkout: 

```
steps:
       # first checkout
      - name: Checkout
        uses: actions/checkout@v3
        with:
          ref: ${{ github.head_ref }}
      - name: Build and deploy to Dagster Cloud serverless
        uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v0.1
        with:
          dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
          location: ${{ toJson(matrix.location) }}
          organization_id: ${{ secrets.ORGANIZATION_ID }}
          # disable checkout within the action
          checkout_repo: 'false'
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Does anyone know an easy way to actually _test_ this change? I couldn't figure out how... and I'm not 100% certain the syntax for referencing an input in the `if` clause is correct 😬 

We could also base the flag off of an env reference instead of an input. But I like that inputs are documented.