### PR TITLE
Enable ssh for docker deploys in hybrid and serverless docker/build-push-action step

### DIFF
--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -57,7 +57,7 @@ runs:
       if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/build-push-action@v3
       with:
-        ssh: default
+        ssh: ${{ env.DOCKER_BUILD_SSH }}
         context: ${{ fromJson(inputs.location).directory }}
         push: true
         tags: "${{ fromJson(inputs.location).registry }}:${{ github.sha }}"

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -57,6 +57,7 @@ runs:
       if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/build-push-action@v3
       with:
+        ssh: default
         context: ${{ fromJson(inputs.location).directory }}
         push: true
         tags: "${{ fromJson(inputs.location).registry }}:${{ github.sha }}"

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -49,6 +49,7 @@ runs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
+        ssh: default
         context: ${{ fromJson(inputs.location).directory }}
         push: true
         tags: "${{ fromJson(inputs.location).registry }}:${{ github.sha }}"

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
-        ssh: default
+        ssh: ${{ env.DOCKER_BUILD_SSH }}
         context: ${{ fromJson(inputs.location).directory }}
         push: true
         tags: "${{ fromJson(inputs.location).registry }}:${{ github.sha }}"

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -81,7 +81,7 @@ runs:
       if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/build-push-action@v3
       with:
-        ssh: default
+        ssh: ${{ env.DOCKER_BUILD_SSH }}
         context: ${{ fromJSON(inputs.location).directory }}
         push: true
         tags: "${{ env.REGISTRY_URL }}:prod-${{ fromJson(inputs.location).name }}-${{ github.sha }}"

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -81,6 +81,7 @@ runs:
       if: ${{ github.event.pull_request.state != 'closed' }}
       uses: docker/build-push-action@v3
       with:
+        ssh: default
         context: ${{ fromJSON(inputs.location).directory }}
         push: true
         tags: "${{ env.REGISTRY_URL }}:prod-${{ fromJson(inputs.location).name }}-${{ github.sha }}"

--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -73,7 +73,7 @@ runs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
-        ssh: default
+        ssh: ${{ env.DOCKER_BUILD_SSH }}
         context: ${{ fromJson(inputs.location).directory }}
         push: true
         tags: "${{ env.REGISTRY_URL }}:${{ inputs.deployment }}-${{ fromJson(inputs.location).name }}-${{ github.sha }}"

--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -73,6 +73,7 @@ runs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
+        ssh: default
         context: ${{ fromJson(inputs.location).directory }}
         push: true
         tags: "${{ env.REGISTRY_URL }}:${{ inputs.deployment }}-${{ fromJson(inputs.location).name }}-${{ github.sha }}"


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster-cloud-action/issues/86

Verified that this is a no-op for existing docker deploys when DOCKER_BUILD_SSH is not set. When `env: DOCKER_BUILD_SSH: default` is set, this forwards ssh credentials to the docker build for anyone that needs it.
