### PR TITLE
Include package dir in git URL metadata

### DIFF
--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.10"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.11"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.11"
   entrypoint: "/deploy.sh"
   env:
     OUTPUT_FILE: $GITHUB_OUTPUT

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.10"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
   entrypoint: "/deploy.sh"
   env:
     OUTPUT_FILE: $GITHUB_OUTPUT

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.11"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.10"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.11"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.10"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.11"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.10"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:include-in-git-url"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -102,6 +102,10 @@ else
     export DEPLOYMENT_NAME=$INPUT_DEPLOYMENT
 fi
 
+if [ -z $INPUT_DIRECTORY ]; then
+    COMMIT_URL="${COMMIT_URL}/${INPUT_DIRECTORY}"
+fi
+
 if [ -z $DEPLOYMENT_NAME ]; then
     echo "::error title=Failed to update branch deployment::Failed to update branch deployment"
     exit 1

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -102,7 +102,7 @@ else
     export DEPLOYMENT_NAME=$INPUT_DEPLOYMENT
 fi
 
-if [ -z $INPUT_DIRECTORY ]; then
+if [ ! -z $INPUT_DIRECTORY ]; then
     COMMIT_URL="${COMMIT_URL}/${INPUT_DIRECTORY}"
 fi
 


### PR DESCRIPTION
## Summary

Appends the package directory in the GH repo to the git URL metadata submitted by the deploy step to Dagster Cloud. This allows us to link directly to the package containing the loaded user code, and down the line would enable us to e.g. link to implementations of particular assets.

## Test Plan

See https://prha-2.dagster.cloud/6b91a131890e81cc24ac86afa6a0ac0c6f3c10b0/locations and click link