### PR TITLE
Switch GitHub workflow to the dagster-cloud CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 # builder.pex
 src/pex-builder/build
 
+# locally built wheels for Dockerfile.dagster-manylinux-builder
+wheels/*whl

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -68,10 +68,11 @@ runs:
         $FLAG_DEPS_CACHE_FROM
       shell: bash
 
-    # - if: ${{ inputs.deploy != 'true' }}
-    #   run: >
-    #     cd $ACTION_REPO &&
-    #     generated/gha/dagster-cloud.pex serverless build-python-executable
-    #     $SOURCE_DIRECTORY ${{ inputs.build_output_dir }}
-    #     --python-version=${{ inputs.python_version }}
-    #   shell: bash
+    - if: ${{ inputs.deploy != 'true' }}
+      run: >
+        cd $ACTION_REPO &&
+        generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint
+        serverless build-python-executable
+        $SOURCE_DIRECTORY ${{ inputs.build_output_dir }}
+        --python-version=${{ inputs.python_version }}
+      shell: bash

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -54,13 +54,15 @@ runs:
       with:
         python-version: ${{ inputs.python_version }}
 
+    - run: >
+        echo SOURCE_DIRECTORY=$(dirname ${{ inputs.dagster_cloud_file }}) >> $GITHUB_ENV
+
     - if: ${{ inputs.deploy == 'true' }}
       run: >
         cd $ACTION_REPO &&
-        /usr/bin/python src/deploy_pex.py -m builder.deploy
-        ${{ inputs.dagster_cloud_file }} ${{ inputs.build_output_dir }}
+        /usr/bin/python src/deploy_pex.py
+        $SOURCE_DIRECTORY
         --python-version=${{ inputs.python_version }}
-        --upload-pex --update-code-location
         $FLAG_DEPS_CACHE_TO
         $FLAG_DEPS_CACHE_FROM
       shell: bash
@@ -68,9 +70,7 @@ runs:
     - if: ${{ inputs.deploy != 'true' }}
       run: >
         cd $ACTION_REPO &&
-        generated/gha/builder.pex -m builder.deploy 
-        ${{ inputs.dagster_cloud_file }} ${{ inputs.build_output_dir }}
+        generated/gha/dagster-cloud.pex serverless build-python-executable
+        $SOURCE_DIRECTORY ${{ inputs.build_output_dir }}
         --python-version=${{ inputs.python_version }}
-        $FLAG_DEPS_CACHE_TO
-        $FLAG_DEPS_CACHE_FROM
       shell: bash

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -56,6 +56,7 @@ runs:
 
     - run: >
         echo SOURCE_DIRECTORY=$(dirname ${{ inputs.dagster_cloud_file }}) >> $GITHUB_ENV
+      shell: bash
 
     - if: ${{ inputs.deploy == 'true' }}
       run: >

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -62,16 +62,16 @@ runs:
       run: >
         cd $ACTION_REPO &&
         /usr/bin/python src/deploy_pex.py
-        $SOURCE_DIRECTORY
+        ${{ inputs.dagster_cloud_file }}
         --python-version=${{ inputs.python_version }}
         $FLAG_DEPS_CACHE_TO
         $FLAG_DEPS_CACHE_FROM
       shell: bash
 
-    - if: ${{ inputs.deploy != 'true' }}
-      run: >
-        cd $ACTION_REPO &&
-        generated/gha/dagster-cloud.pex serverless build-python-executable
-        $SOURCE_DIRECTORY ${{ inputs.build_output_dir }}
-        --python-version=${{ inputs.python_version }}
-      shell: bash
+    # - if: ${{ inputs.deploy != 'true' }}
+    #   run: >
+    #     cd $ACTION_REPO &&
+    #     generated/gha/dagster-cloud.pex serverless build-python-executable
+    #     $SOURCE_DIRECTORY ${{ inputs.build_output_dir }}
+    #     --python-version=${{ inputs.python_version }}
+    #   shell: bash

--- a/src/Dockerfile.dagster-manylinux-builder
+++ b/src/Dockerfile.dagster-manylinux-builder
@@ -7,12 +7,13 @@
 # To publish a new version:
 # $ cd path/to/dagster-cloud-action
 #
-# Update generated/gha/builder.pex (optional)
+# (optional) By default dagster-cloud from PyPI will be included. To build from a local version, build the
+# wheels and drop into the wheels/ folder
 #
 # $ echo $GITHUB-PAT | docker login ghcr.io -u USERNAME --password-stdin
 #
-# $ docker build . -f src/Dockerfile.dagster-manylinux-builder -t ghcr.io/dagster-io/dagster-manylinux-builder:dev
-# $ docker push ghcr.io/dagster-io/dagster-manylinux-builder:dev
+# $ docker build . -f src/Dockerfile.dagster-manylinux-builder -t ghcr.io/dagster-io/dagster-manylinux-builder:latest
+# $ docker push ghcr.io/dagster-io/dagster-manylinux-builder:latest
 
 # See dagster-cloud (docker_runner.py) for code that uses this image.
 
@@ -23,6 +24,12 @@ FROM --platform=linux/amd64 quay.io/pypa/manylinux2014_x86_64:latest
 
 # Add all the relevant Python binaries to the PATH
 ENV PATH="/opt/python/cp38-cp38/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:$PATH"
+
+# To install unreleased versions, build the wheels and drop them in this directory
+COPY wheels /wheels
+
+# Install dagster-cloud
+RUN python3.8 -m pip install dagster-cloud --find-links file:///wheels/
 
 COPY generated/gha/builder.pex /builder.pex
 

--- a/src/Dockerfile.dagster-manylinux-builder
+++ b/src/Dockerfile.dagster-manylinux-builder
@@ -14,7 +14,7 @@
 # $ docker build . -f src/Dockerfile.dagster-manylinux-builder -t ghcr.io/dagster-io/dagster-manylinux-builder:dev
 # $ docker push ghcr.io/dagster-io/dagster-manylinux-builder:dev
 
-# See ./deploy_pex.py for code that uses this image.
+# See dagster-cloud (docker_runner.py) for code that uses this image.
 
 # ---
 

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -98,7 +98,7 @@ def deploy_pex(args, build_method: str):
             "deploy-python-executable",
             *args,
             f"--location-name={first_location['name']}",
-            f"--location-name={dagster_cloud_yaml}",
+            f"--location-file={dagster_cloud_yaml}",
         ]
     )
 

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -70,6 +70,8 @@ def deploy_pex(args, build_method: str):
     dagster_cloud_yaml = args.pop(0)
     args.insert(0, os.path.dirname(dagster_cloud_yaml))
     args = args + [f"--build-method={build_method}"]
+    commit_hash = os.getenv("GITHUB_SHA")
+    git_url = f"{os.getenv('GITHUB_SERVER_URL')}/{os.getenv('GITHUB_REPOSITORY')}/tree/{commit_hash}"
     return run(
         [
             str(DAGSTER_CLOUD_PEX_PATH),
@@ -80,6 +82,8 @@ def deploy_pex(args, build_method: str):
             *args,
             f"--location-name=*",
             f"--location-file={dagster_cloud_yaml}",
+            f"--git-url={git_url}",
+            f"--commit-hash={commit_hash}",
         ]
     )
 

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -13,7 +13,6 @@
 
 import os
 from pathlib import Path
-import pathlib
 import re
 import subprocess
 import sys
@@ -24,9 +23,7 @@ import yaml
 DAGSTER_CLOUD_PEX_PATH = (
     Path(__file__).parent.parent / "generated/gha/dagster-cloud.pex"
 )
-UPDATE_COMMENT_SCRIPT_PATH = (
-    pathlib.Path(__file__).parent / "create_or_update_comment.py"
-)
+UPDATE_COMMENT_SCRIPT_PATH = Path(__file__).parent / "create_or_update_comment.py"
 
 
 def main():
@@ -181,11 +178,13 @@ def update_pr_comment(deployment_name: str, location_name: str, action: str):
     )
     env = {name: value for name, value in env.items() if value is not None}
     proc = subprocess.run(
-        [sys.executable, str(UPDATE_COMMENT_SCRIPT_PATH)], env=env, check=False
+        [str(DAGSTER_CLOUD_PEX_PATH), str(UPDATE_COMMENT_SCRIPT_PATH)],
+        env=env,
+        check=False,
     )
 
     if proc.returncode:
-        print("Ignoring failure to update PR comment: %s\n%s", proc.stdout, proc.stderr)
+        print(f"Ignoring failure to update PR comment: {proc.stdout}\n{proc.stderr}")
 
 
 def get_pr_number():

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -27,7 +27,9 @@ def main():
 
     if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
         print("Running in a pull request - going to do a branch deployment")
-        deployment_name = get_branch_deployment_name()
+        dagster_cloud_yaml = args[0]
+        project_dir = os.path.dirname(dagster_cloud_yaml)
+        deployment_name = get_branch_deployment_name(project_dir)
     else:
         print("Going to do a full deployment.")
         deployment_name = None
@@ -75,7 +77,7 @@ def run(args):
     return returncode, output
 
 
-def get_branch_deployment_name():
+def get_branch_deployment_name(project_dir):
     returncode, output = run(
         [
             str(DAGSTER_CLOUD_PEX_PATH),
@@ -83,6 +85,7 @@ def get_branch_deployment_name():
             "dagster_cloud_cli.entrypoint",
             "ci",
             "branch-deployment",
+            project_dir,
         ]
     )
     if not returncode:

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -24,6 +24,9 @@ import yaml
 DAGSTER_CLOUD_PEX_PATH = (
     Path(__file__).parent.parent / "generated/gha/dagster-cloud.pex"
 )
+UPDATE_COMMENT_SCRIPT_PATH = (
+    pathlib.Path(__file__).parent / "create_or_update_comment.py"
+)
 
 
 def main():
@@ -161,8 +164,7 @@ def update_pr_comment(deployment_name: str, location_name: str, action: str):
         print("Not in a pull request, will not post PR comment")
         return
 
-    script_path = pathlib.Path(__file__).parent / "create_or_update_comment.py"
-    if not script_path.exists:
+    if not UPDATE_COMMENT_SCRIPT_PATH.exists:
         print(f"Could not find script_path, will not post PR comment")
         return
 
@@ -178,7 +180,9 @@ def update_pr_comment(deployment_name: str, location_name: str, action: str):
         }
     )
     env = {name: value for name, value in env.items() if value is not None}
-    proc = subprocess.run([str(script_path)], env=env, check=False)
+    proc = subprocess.run(
+        [sys.executable, str(UPDATE_COMMENT_SCRIPT_PATH)], env=env, check=False
+    )
 
     if proc.returncode:
         print("Ignoring failure to update PR comment: %s\n%s", proc.stdout, proc.stderr)

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -88,7 +88,7 @@ def get_branch_deployment_name(project_dir):
             project_dir,
         ]
     )
-    if not returncode:
+    if returncode:
         print("Could not determine branch deployment")
         sys.exit(1)
     name = "".join(output).strip()

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
 # Switches PEX deploy behavior based on github runner's ubuntu version
-# ubuntu-20.04 can always build pexes that work on our target platform
-# ubuntu-22.04 can only build pexes if there are no sdists (source only packages)
+# - ubuntu-20.04 can always build pexes that work on our target platform
+# - ubuntu-22.04 can only build pexes if there are no sdists (source only packages)
 
 # On ubuntu-20.04: forward args to `dagster-cloud --build-method=local`
 # On ubuntu-22.04: forward args to `dagster-cloud --build-method=docker`
 # - Sometimes 22.04 may try to build sdists but build the wrong version (since we are not yet
 #   using --complete-platform for pex). To avoid this situation, we always build dependencies in the
 #   right docker environment on 22.04. Note if dependencies are not being built, docker will not
-#   be used. The source.pex is built using the local environment.
+#   be used. The source.pex is always built using the local environment.
 
 from pathlib import Path
 import subprocess

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -191,7 +191,6 @@ def get_pr_number():
     # Extract pull request number from GITHUB_REF
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-event-pull_request
     github_ref = os.getenv("GITHUB_REF", "")
-    print("Looking for a PR number in", repr(github_ref))
     mo = re.match(r"refs/pull/(\d+)", github_ref)
     if not mo:
         return None

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -4,21 +4,20 @@
 # ubuntu-20.04 can always build pexes that work on our target platform
 # ubuntu-22.04 can only build pexes if there are no sdists (source only packages)
 
-# On ubuntu-20.04: forward args to builder.pex
+# On ubuntu-20.04: forward args to `dagster-cloud --build-method=local`
+# On ubuntu-22.04: forward args to `dagster-cloud --build-method=docker`
+# - Sometimes 22.04 may try to build sdists but build the wrong version (since we are not yet
+#   using --complete-platform for pex). To avoid this situation, we always build dependencies in the
+#   right docker environment on 22.04. Note if dependencies are not being built, docker will not
+#   be used. The source.pex is built using the local environment.
 
-# On ubuntu-22.04:
-#   Try to build without sdists
-#     If success: all good (no sdists were involved)
-#     If failure: run builder.pex within the dagster-manylinux-builder docker image
-
-import os
 from pathlib import Path
 import subprocess
 import sys
 
-BUILDER_PEX_PATH = Path(__file__).parent.parent / "generated/gha/builder.pex"
-DOCKER_PATH = "/usr/bin/docker"
-DOCKER_IMAGE = "ghcr.io/dagster-io/dagster-manylinux-builder:v0.1"
+DAGSTER_CLOUD_PEX_PATH = (
+    Path(__file__).parent.parent / "generated/gha/dagster-cloud.pex"
+)
 
 
 def main():
@@ -26,28 +25,9 @@ def main():
     ubuntu_version = get_runner_ubuntu_version()
     print("Running on Ubuntu", ubuntu_version)
     if ubuntu_version == "20.04":
-        returncode, output = deploy_pex_from_current_environment(args, build_sdists=True)
+        returncode, output = deploy_pex(args, build_method="local")
     else:
-        returncode, output = deploy_pex_from_current_environment(args, build_sdists=False)
-        if returncode:
-            dep_failures = dependency_failure_lines(output)
-            if dep_failures:
-                try:
-                    print(
-                        "::group::Preparing a Docker build environment to build the PEX files",
-                        flush=True,
-                    )
-                    print(
-                        "Going to build dependencies within a Docker build environment "
-                        "to resolve missing binary packages for the following:"
-                    )
-                    for line in dep_failures:
-                        print(f"- {line}")
-
-                    returncode, output = deploy_pex_from_docker(args)
-                finally:
-                    print("::endgroup::", flush=True)
-
+        returncode, output = deploy_pex(args, build_method="docker")
     if returncode:
         print(
             "::error Title=Deploy failed::Failed to deploy Python Executable. "
@@ -85,116 +65,16 @@ def run(args):
     return returncode, output
 
 
-def dependency_failure_lines(lines):
-    return [line for line in lines if "No matching distribution" in line]
-
-
-def deploy_pex_from_current_environment(args, build_sdists: bool):
-    if build_sdists:
-        args = args + ["--build-sdists"]
-    else:
-        args = args + ["--no-build-sdists"]
-
+def deploy_pex(args, build_method: str):
+    args = args + [f"--build-method={build_method}"]
     return run(
         [
-            str(BUILDER_PEX_PATH),
+            str(DAGSTER_CLOUD_PEX_PATH),
+            "serverless",
+            "deploy-python-executable",
             *args,
         ]
     )
-
-
-def deploy_pex_from_docker(args):
-    # This invokes the docker cli to run builder.pex.
-    # The problem with using the a Github custom docker action instead is that the docker image
-    # is always downloaded (even if it is a conditional step that is never run). Using the cli
-    # makes the download lazy (takes about 40 seconds). But requires a bunch of directory and
-    # env mappings. These have been copied from an actual Github docker action.
-    local_github_workspace_path = os.environ["GITHUB_WORKSPACE"]
-    github_docker_envs = [
-        "GITHUB_WORKSPACE=/github/workspace",
-        "GITHUB_EVENT_PATH=/github/workflow/event.json",
-        "GITHUB_WORKFLOW",
-        "DAGSTER_CLOUD_URL",
-        "DAGSTER_CLOUD_API_TOKEN",
-        "ENABLE_FAST_DEPLOYS",
-        "ACTION_REPO",
-        "FLAG_DEPS_CACHE_FROM",
-        "FLAG_DEPS_CACHE_TO",
-        "pythonLocation",
-        "LD_LIBRARY_PATH",
-        "GITHUB_TOKEN",
-        "HOME=/github/home",
-        "GITHUB_JOB",
-        "GITHUB_REF",
-        "GITHUB_SHA",
-        "GITHUB_REPOSITORY",
-        "GITHUB_REPOSITORY_OWNER",
-        "GITHUB_RUN_ID",
-        "GITHUB_RUN_NUMBER",
-        "GITHUB_RETENTION_DAYS",
-        "GITHUB_RUN_ATTEMPT",
-        "GITHUB_ACTOR",
-        "GITHUB_TRIGGERING_ACTOR",
-        "GITHUB_HEAD_REF",
-        "GITHUB_BASE_REF",
-        "GITHUB_EVENT_NAME",
-        "GITHUB_SERVER_URL",
-        "GITHUB_API_URL",
-        "GITHUB_GRAPHQL_URL",
-        "GITHUB_REF_NAME",
-        "GITHUB_REF_PROTECTED",
-        "GITHUB_REF_TYPE",
-        "GITHUB_ACTION",
-        "GITHUB_ACTION_REPOSITORY",
-        "GITHUB_ACTION_REF",
-        "GITHUB_PATH",
-        "GITHUB_ENV",
-        "GITHUB_STEP_SUMMARY",
-        "GITHUB_STATE",
-        "GITHUB_OUTPUT",
-        "GITHUB_ACTION_PATH",
-        "RUNNER_OS",
-        "RUNNER_ARCH",
-        "RUNNER_NAME",
-        "RUNNER_TOOL_CACHE",
-        "RUNNER_TEMP",
-        "RUNNER_WORKSPACE",
-        "ACTIONS_RUNTIME_URL",
-        "ACTIONS_RUNTIME_TOKEN",
-        "ACTIONS_CACHE_URL",
-        "GITHUB_ACTIONS=true",
-        "CI=true",
-    ]
-    github_docker_mounts = [
-        f"{local_github_workspace_path}:/github/workspace",
-        "/home/runner/work/_temp/_github_workflow:/github/workflow",
-        "/var/run/docker.sock:/var/run/docker.sock",
-        "/home/runner/work/_temp/_github_home:/github/home",
-        "/home/runner/work/_temp/_runner_file_commands:/github/file_commands",
-    ]
-
-    docker_run_args = [
-        "--workdir",
-        "/github/workspace",
-        "--rm",
-        "--entrypoint",
-        "/usr/bin/bash",
-    ]
-    for env in github_docker_envs:
-        docker_run_args.extend(["-e", env])
-    for mnt in github_docker_mounts:
-        docker_run_args.extend(["-v", mnt])
-    builder_pex_args = " ".join(args) + " --build-sdists"
-    # map local paths to mounted paths
-    builder_pex_args = builder_pex_args.replace(local_github_workspace_path, "/github/workspace")
-    docker_run_args.extend(
-        [
-            DOCKER_IMAGE,
-            "-c",
-            f"git config --global --add safe.directory /github/workspace/project-repo; /builder.pex {builder_pex_args}",
-        ]
-    )
-    return run(["/usr/bin/docker", "run", *docker_run_args])
 
 
 if __name__ == "__main__":

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -92,6 +92,8 @@ def deploy_pex(args, build_method: str):
     return run(
         [
             str(DAGSTER_CLOUD_PEX_PATH),
+            "-m",
+            "dagster-cloud",
             "serverless",
             "deploy-python-executable",
             *args,

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -148,11 +148,13 @@ def deploy_pex(args, deployment_name: Optional[str], build_method: str):
 
 
 def notify(deployment_name: Optional[str], locations: List[str], action: str):
+    if deployment_name is None:
+        return
     for location_name in locations:
         update_pr_comment(deployment_name, location_name, action)
 
 
-def update_pr_comment(deployment_name: Optional[str], location_name: str, action: str):
+def update_pr_comment(deployment_name: str, location_name: str, action: str):
     # action is one of "pending", "success", "failed"
     pr_id = get_pr_number()
     if not pr_id:
@@ -185,7 +187,9 @@ def update_pr_comment(deployment_name: Optional[str], location_name: str, action
 def get_pr_number():
     # Extract pull request number from GITHUB_REF
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-event-pull_request
-    mo = re.match(r"/refs/pull/({\d+})", os.getenv("GITHUB_REF", ""))
+    github_ref = os.getenv("GITHUB_REF", "")
+    print("Looking for a PR number in", repr(github_ref))
+    mo = re.match(r"/refs/pull/({\d+})", github_ref)
     if not mo:
         return None
     return mo.group(1)

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -103,7 +103,7 @@ def deploy_pex(args, deployment_name: Optional[str], build_method: str):
     commit_hash = os.getenv("GITHUB_SHA")
     git_url = f"{os.getenv('GITHUB_SERVER_URL')}/{os.getenv('GITHUB_REPOSITORY')}/tree/{commit_hash}"
     if deployment_name:
-        deployment_flag = [f"--deployment={deployment_name}"]
+        deployment_flag = [f"--url={os.getenv('DAGSTER_CLOUD_URL')}/{deployment_name}"]
     else:
         deployment_flag = []
     return run(

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -12,7 +12,6 @@
 #   be used. The source.pex is always built using the local environment.
 
 import os
-import yaml
 from pathlib import Path
 import subprocess
 import sys
@@ -20,21 +19,6 @@ import sys
 DAGSTER_CLOUD_PEX_PATH = (
     Path(__file__).parent.parent / "generated/gha/dagster-cloud.pex"
 )
-
-
-def parse_workspace(dagster_cloud_file):
-    workspace = dagster_cloud_file
-
-    with open(workspace) as f:
-        workspace_contents = f.read()
-    workspace_contents_yaml = yaml.safe_load(workspace_contents)
-
-    return [
-        {
-            "name": location["location_name"],
-        }
-        for location in workspace_contents_yaml["locations"]
-    ]
 
 
 def main():
@@ -86,9 +70,6 @@ def deploy_pex(args, build_method: str):
     dagster_cloud_yaml = args.pop(0)
     args.insert(0, os.path.dirname(dagster_cloud_yaml))
     args = args + [f"--build-method={build_method}"]
-    first_location = parse_workspace(dagster_cloud_yaml)[0]
-    print(f"Deploying {first_location}")
-
     return run(
         [
             str(DAGSTER_CLOUD_PEX_PATH),
@@ -97,7 +78,7 @@ def deploy_pex(args, build_method: str):
             "serverless",
             "deploy-python-executable",
             *args,
-            f"--location-name={first_location['name']}",
+            f"--location-name=*",
             f"--location-file={dagster_cloud_yaml}",
         ]
     )

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -189,7 +189,7 @@ def get_pr_number():
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-event-pull_request
     github_ref = os.getenv("GITHUB_REF", "")
     print("Looking for a PR number in", repr(github_ref))
-    mo = re.match(r"/refs/pull/({\d+})", github_ref)
+    mo = re.match(r"refs/pull/(\d+)", github_ref)
     if not mo:
         return None
     return mo.group(1)

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -93,7 +93,7 @@ def deploy_pex(args, build_method: str):
         [
             str(DAGSTER_CLOUD_PEX_PATH),
             "-m",
-            "dagster-cloud",
+            "dagster_cloud_cli.entrypoint",
             "serverless",
             "deploy-python-executable",
             *args,

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -25,9 +25,11 @@ DAGSTER_CLOUD_PEX_PATH = (
 def main():
     args = sys.argv[1:]
 
-    if os.getenv("GITHUB_EVENT") == "pull_request":
+    if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+        print("Running in a pull request - going to do a branch deployment")
         deployment_name = get_branch_deployment_name()
     else:
+        print("Going to do a full deployment.")
         deployment_name = None
 
     ubuntu_version = get_runner_ubuntu_version()

--- a/src/pex-builder/build-dagster-cloud-pex.sh
+++ b/src/pex-builder/build-dagster-cloud-pex.sh
@@ -24,12 +24,10 @@ set -x
 # --pip-version and --resolver-version recommended by the pex team, uses the latest dependency
 #   resolution logic
 # --venv prepend unpacks the pex into a venv before execution, nice to have for debugging
-# -c specifies the default entrypoint
 pex $DAGSTER_CLOUD_SOURCE_PACKAGE $DAGSTER_CLOUD_CLI_SOURCE_PACKAGE \
     -o dagster-cloud.pex \
     --platform=manylinux2014_x86_64-cp-38-cp38 \
     --platform=macosx_12_0_x86_64-cp-38-cp38 \
     --pip-version=23.0 \
     --resolver-version=pip-2020-resolver \
-    --venv prepend \
-    -c dagster-cloud
+    --venv prepend

--- a/src/pex-builder/build-dagster-cloud-pex.sh
+++ b/src/pex-builder/build-dagster-cloud-pex.sh
@@ -24,7 +24,7 @@ set -x
 # --pip-version and --resolver-version recommended by the pex team, uses the latest dependency
 #   resolution logic
 # --venv prepend unpacks the pex into a venv before execution, nice to have for debugging
-pex $DAGSTER_CLOUD_SOURCE_PACKAGE $DAGSTER_CLOUD_CLI_SOURCE_PACKAGE \
+pex $DAGSTER_CLOUD_SOURCE_PACKAGE $DAGSTER_CLOUD_CLI_SOURCE_PACKAGE PyGithub \
     -o dagster-cloud.pex \
     --platform=manylinux2014_x86_64-cp-38-cp38 \
     --platform=macosx_12_0_x86_64-cp-38-cp38 \

--- a/src/pex-builder/build-dagster-cloud-pex.sh
+++ b/src/pex-builder/build-dagster-cloud-pex.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Build dagster-cloud.pex
+# Requires `pex` in the current environment (pip install pex)
+
+if [ -z "$DAGSTER_CLOUD_INTERNAL_BRANCH" ]
+then
+    export DAGSTER_CLOUD_SOURCE_PACKAGE="dagster-cloud"
+    export DAGSTER_CLOUD_CLI_SOURCE_PACKAGE="dagster-cloud-cli"
+else
+    export DAGSTER_CLOUD_SOURCE_PACKAGE="git+https://github.com/dagster-io/internal.git@${DAGSTER_CLOUD_INTERNAL_BRANCH}#egg=dagster-cloud&subdirectory=dagster-cloud/python_modules/dagster-cloud"
+    export DAGSTER_CLOUD_CLI_SOURCE_PACKAGE="git+https://github.com/dagster-io/internal.git@${DAGSTER_CLOUD_INTERNAL_BRANCH}#egg=dagster-cloud-cli&subdirectory=dagster-cloud/python_modules/dagster-cloud-cli"
+fi
+
+echo "Building dagster-cloud.pex from "
+echo " - $DAGSTER_CLOUD_SOURCE_PACKAGE"
+echo " - $DAGSTER_CLOUD_CLI_SOURCE_PACKAGE"
+echo ""
+
+set -x
+
+# Flags used:
+# --platform specifies for a standard linux environment which works in GitHub
+# --pip-version and --resolver-version recommended by the pex team, uses the latest dependency
+#   resolution logic
+# --venv prepend unpacks the pex into a venv before execution, nice to have for debugging
+# -c specifies the default entrypoint
+pex $DAGSTER_CLOUD_SOURCE_PACKAGE $DAGSTER_CLOUD_CLI_SOURCE_PACKAGE \
+    -o dagster-cloud.pex \
+    --platform=manylinux2014_x86_64-cp-38-cp38 \
+    --platform=macosx_12_0_x86_64-cp-38-cp38 \
+    --pip-version=23.0 \
+    --resolver-version=pip-2020-resolver \
+    --venv prepend \
+    -c dagster-cloud


### PR DESCRIPTION
Replaces the `builder.pex -m` style calls with `dagster-cloud` calls. We still build a pex (dagster-cloud.pex) for faster startup time.

Also update the manylinux builder to be used with `build-python-executable`.