### PR TITLE
Bump all dagster-cloud-action references to 0.1.20

### DIFF
--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.12"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.12"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.12"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.12"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.12"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/gitlab/hybrid-ci.yml
+++ b/gitlab/hybrid-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     - python /parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -39,7 +39,7 @@ deploy-docker:
   dependencies:
     - build-image
     - parse-workspace
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL
@@ -59,7 +59,7 @@ deploy-docker-branch:
   dependencies:
     - build-image
     - parse-workspace
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -94,7 +94,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   when: manual
   only:
     - merge_requests

--- a/gitlab/serverless-ci.yml
+++ b/gitlab/serverless-ci.yml
@@ -7,7 +7,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -35,7 +35,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   when: manual
   only:
     - merge_requests
@@ -60,6 +60,6 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     - /gitlab_action/deploy.py ./dagster_cloud.yaml

--- a/gitlab/serverless-legacy-ci.yml
+++ b/gitlab/serverless-legacy-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     - python /gitlab_action/parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -23,7 +23,7 @@ parse-workspace:
 
 fetch-registry-info:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script: dagster-cloud serverless registry-info --url $DAGSTER_CLOUD_URL/prod --api-token $DAGSTER_CLOUD_API_TOKEN | grep '=' >> registry.env
   artifacts:
     reports:
@@ -53,7 +53,7 @@ deploy-docker:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL/prod
@@ -74,7 +74,7 @@ deploy-docker-branch:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -109,7 +109,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.19
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
   when: manual
   only:
     - merge_requests


### PR DESCRIPTION
Retagged 0.1.19 as 0.1.20 - lets sync all version numbers to the latest point release as part of doing each release. 