### PR TITLE
Implement a simple release script and also prepare 0.1.21 using it

### DIFF
--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.21"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.21"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.21"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.21"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.20"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.21"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/gitlab/hybrid-ci.yml
+++ b/gitlab/hybrid-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     - python /parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -39,7 +39,7 @@ deploy-docker:
   dependencies:
     - build-image
     - parse-workspace
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL
@@ -59,7 +59,7 @@ deploy-docker-branch:
   dependencies:
     - build-image
     - parse-workspace
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -94,7 +94,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   when: manual
   only:
     - merge_requests

--- a/gitlab/serverless-ci.yml
+++ b/gitlab/serverless-ci.yml
@@ -7,7 +7,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -35,7 +35,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   when: manual
   only:
     - merge_requests
@@ -60,6 +60,6 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     - /gitlab_action/deploy.py ./dagster_cloud.yaml

--- a/gitlab/serverless-legacy-ci.yml
+++ b/gitlab/serverless-legacy-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     - python /gitlab_action/parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -23,7 +23,7 @@ parse-workspace:
 
 fetch-registry-info:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script: dagster-cloud serverless registry-info --url $DAGSTER_CLOUD_URL/prod --api-token $DAGSTER_CLOUD_API_TOKEN | grep '=' >> registry.env
   artifacts:
     reports:
@@ -53,7 +53,7 @@ deploy-docker:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL/prod
@@ -74,7 +74,7 @@ deploy-docker-branch:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -109,7 +109,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.20
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.21
   when: manual
   only:
     - merge_requests

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -112,7 +112,11 @@ def create_rc(
     if check_workdir:
         ensure_clean_workdir()
     branch = ensure_in_branch()
-    info("Preparing a new RC")
+    info(f"Preparing a new RC in {branch}")
+
+    if not re.match(r"^[0-9.]+$", version_tag):
+        error(f"Invalid version tag {version_tag}")
+        sys.exit(1)
 
     update_dagster_cloud_pex()
     if execute_tests:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -99,6 +99,8 @@ def update_docker_action_references(
                 text = input_text.replace(previous_image_name, image_name)
                 if text != input_text:
                     print(path)
+                    with open(path, "w", encoding="utf-8") as f:
+                        f.write(text)
 
 
 @app.command()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -138,7 +138,7 @@ def ensure_clean_workdir():
 
 def ensure_in_branch():
     branch = get_branch_name()
-    if branch != "main":
+    if branch == "main":
         error("ERROR: Not in branch")
         sys.exit(1)
     return branch

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+from contextlib import contextmanager
+import glob
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import List
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+app = typer.Typer()
+
+
+@contextmanager
+def chdir(path: str):
+    repo_root = Path(__file__).parent.parent
+    curdir = Path(os.curdir).absolute()
+    try:
+        os.chdir(repo_root / path)
+        yield
+    finally:
+        os.chdir(curdir)
+
+
+def info(msg):
+    console.print(msg, style="blue")
+
+
+def error(msg):
+    console.print(msg, style="red")
+
+
+@app.command()
+def run_tests():
+    info("Running tests")
+    subprocess.run(["pytest", "tests"], check=True)
+
+
+@app.command()
+def build_docker_action(version_tag: str, publish_docker_action: bool = True):
+    pattern = get_docker_action_image_name('.+?"')
+    image_name = get_docker_action_image_name(version_tag)
+    info(f"Building {image_name}")
+    with chdir("src"):
+        output = subprocess.check_output(
+            [
+                "docker",
+                "build",
+                ".",
+                "-t",
+                image_name,
+            ],
+            encoding="utf-8",
+        )
+        print(output)
+        if publish_docker_action:
+            info(f"Publishing {image_name}")
+            subprocess.check_output(
+                [
+                    "docker",
+                    "push",
+                    image_name,
+                ],
+                encoding="utf-8",
+            )
+            print(output)
+
+
+@app.command()
+def update_dagster_cloud_pex():
+    with chdir("src/pex-builder"):
+        info("Building generated/gha/dagster-cloud.pex")
+        output = subprocess.check_output(
+            "./build-dagster-cloud-pex.sh", shell=True, encoding="utf-8"
+        )
+        print(output)
+        shutil.move("dagster-cloud.pex", "../../generated/gha/dagster-cloud.pex")
+
+
+@app.command()
+def update_docker_action_references(
+    previous_version_tag,
+    version_tag,
+    glob_patterns: List[str] = ["**/*yaml", "**/*yml"],
+):
+    image_name = get_docker_action_image_name(version_tag)
+    previous_image_name = get_docker_action_image_name(previous_version_tag)
+    info(f"Updating references from {previous_image_name} to {image_name}")
+    with chdir("."):
+        for pattern in glob_patterns:
+            for path in glob.glob(pattern, recursive=True):
+                input_text = open(path, encoding="utf-8").read()
+                text = input_text.replace(previous_image_name, image_name)
+                if text != input_text:
+                    print(path)
+
+
+@app.command()
+def create_rc(
+    version_tag: str,
+    previous_version_tag: str,
+    check_workdir: bool = True,
+    execute_tests: bool = True,
+    publish_docker_action: bool = True,
+):
+    if check_workdir:
+        ensure_clean_workdir()
+    branch = ensure_in_branch()
+    info("Preparing a new RC")
+
+    update_dagster_cloud_pex()
+    if execute_tests:
+        run_tests()
+    build_docker_action(version_tag, publish_docker_action)
+    update_docker_action_references(previous_version_tag, version_tag)
+    info(f"Updated working directory for {version_tag}")
+
+
+def ensure_clean_workdir():
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"], capture_output=True, check=False
+    )
+    if proc.stdout or proc.stderr:
+        error("ERROR: Git working directory not clean:")
+        error((proc.stdout + proc.stderr).decode("utf-8"))
+        sys.exit(1)
+
+
+def ensure_in_branch():
+    branch = get_branch_name()
+    if branch != "main":
+        error("ERROR: Not in branch")
+        sys.exit(1)
+    return branch
+
+
+def get_branch_name():
+    proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, check=True
+    )
+    return proc.stdout.decode("utf-8").strip()
+
+
+def get_docker_action_image_name(version_tag: str) -> str:
+    return f"ghcr.io/dagster-io/dagster-cloud-action:{version_tag}"
+
+
+if __name__ == "__main__":
+    try:
+        app()
+    except subprocess.CalledProcessError as err:
+        error("Subprocess failed")
+        error(err.args)
+        if err.output:
+            error(err.output.decode("utf-8"))
+        if err.stderr:
+            error(err.stderr.decode("utf-8"))
+        raise
+        sys.exit(2)

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.12-slim
+FROM --platform=linux/amd64 python:3.8.12-slim
 
 # Install deps
 RUN apt update && apt install git -y

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 import tempfile
 from contextlib import contextmanager
@@ -12,19 +11,22 @@ import requests
 
 
 @contextmanager
-def run_builder(builder_pex_path, builder_args: List[str]):
+def run_dagster_cloud_serverless_cmd(dagster_cloud_pex_path, args: List[str]):
     with tempfile.TemporaryDirectory() as build_output_dir:
         proc = subprocess.run(
             [
-                builder_pex_path,
-                *builder_args,
+                dagster_cloud_pex_path,
+                "-m",
+                "dagster_cloud_cli.entrypoint",
+                "serverless",
+                *args,
                 build_output_dir,
             ],
             capture_output=True,
         )
         if proc.returncode:
             raise ValueError(
-                "Failed to run builder.pex:"
+                "Failed to run dagster-cloud.pex:"
                 + (proc.stdout + proc.stderr).decode("utf-8")
             )
 
@@ -37,12 +39,16 @@ def run_builder(builder_pex_path, builder_args: List[str]):
         yield (build_output_dir, list(pex_files), list(set(all_files) - pex_files))
 
 
-def test_pex_deploy_build_only(repo_root, builder_pex_path):
-    dagster_project1_yaml = (
-        repo_root / "tests/test-repos/dagster_project1/dagster_cloud.yaml"
-    )
-    with run_builder(
-        builder_pex_path, ["-m", "builder.deploy", str(dagster_project1_yaml)]
+def test_pex_build_only(repo_root, dagster_cloud_pex_path):
+    dagster_project1 = repo_root / "tests/test-repos/dagster_project1"
+    with run_dagster_cloud_serverless_cmd(
+        dagster_cloud_pex_path,
+        [
+            "build-python-executable",
+            str(dagster_project1),
+            "--api-token=fake",
+            "--url=fake",
+        ],
     ) as (
         build_output_dir,
         pex_files,
@@ -56,292 +62,9 @@ def test_pex_deploy_build_only(repo_root, builder_pex_path):
 
         assert {"source", "deps"} == set(pex_file_by_alias)
 
-        # we are able to run a job defined in the built pex
-        output = subprocess.check_output(
-            [
-                "./" + pex_file_by_alias["source"],
-                *("-m dagster job execute -m dagster_project1  -j job_1".split()),
-            ],
-            env={**os.environ, "PEX_PATH": pex_file_by_alias["deps"]},
-            cwd=build_output_dir,
-            stderr=subprocess.STDOUT,
-            encoding="utf-8",
-        )
 
-        assert "asset_1" in output
-        assert "RUN_SUCCESS" in output
-
-
-def test_pex_deploy_python_file(repo_root, builder_pex_path):
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        shutil.copytree(
-            repo_root / "tests/test-repos/dagster_project_python_file",
-            Path(temp_dir) / "dagster_project_python_file",
-        )
-        dagster_project_yaml = (
-            Path(temp_dir) / "dagster_project_python_file/dagster_cloud.yaml"
-        )
-        os.mkdir(Path(temp_dir) / "dagster_project_python_file/.git")
-        (Path(temp_dir) / "dagster_project_python_file/.git/some-file").touch()
-
-        with run_builder(
-            builder_pex_path, ["-m", "builder.deploy", str(dagster_project_yaml)]
-        ) as (
-            build_output_dir,
-            pex_files,
-            other_files,
-        ):
-            pex_file_by_alias = {
-                filename.split("-", 1)[0]: filename for filename in pex_files
-            }
-
-            # make sure the working_directory was included with the file
-            output = subprocess.check_output(
-                [
-                    "./" + pex_file_by_alias["source"],
-                    "-c",
-                    "import working_directory; print(working_directory.__file__);",
-                ],
-                env={**os.environ, "PEX_PATH": pex_file_by_alias["deps"]},
-                cwd=build_output_dir,
-                stderr=subprocess.STDOUT,
-                encoding="utf-8",
-            )
-
-            assert "working_directory" in output
-            working_dir = output.strip().replace("__init__.py", "root")
-            repo_contents = open(os.path.join(working_dir, "repository.py")).read()
-
-            assert not os.path.exists(os.path.join(working_dir, ".git"))
-            assert "dagster_project_python_file" in repo_contents
-
-
-def test_pex_deps_build(repo_root, builder_pex_path):
-    dagster_project1 = repo_root / "tests/test-repos/dagster_project1/"
-    with tempfile.TemporaryDirectory() as tempdir:
-        # copy the test repo so we can modify it
-        tempdir_path = Path(tempdir)
-        shutil.copytree(
-            repo_root / "tests/test-repos/dagster_project1",
-            tempdir_path / "dagster_project1",
-        )
-
-        import_pandas_code = tempdir_path / "imports_pandas.py"
-        import_pandas_code.write_text('import pandas\nprint("OK")\n')
-
-        # build with original deps
-        with run_builder(
-            builder_pex_path,
-            [
-                "-m",
-                "dagster_cloud_cli.core.pex_builder.deps",
-                str(tempdir_path / "dagster_project1"),
-            ],
-        ) as (build_output_dir, pex_files, other_files):
-            # one deps-HASH.pex is expected
-            assert 1 == len(pex_files)
-            deps_file = pex_files[0]
-
-            output = subprocess.check_output(
-                ["./" + deps_file, "-m", "dagster", "--version"],
-                cwd=build_output_dir,
-                stderr=subprocess.STDOUT,
-                encoding="utf-8",
-            )
-            assert "version" in output
-
-            # try to import nonexistent dependency
-            with pytest.raises(subprocess.CalledProcessError) as exc:
-                subprocess.check_output(
-                    ["./" + deps_file, str(import_pandas_code)],
-                    cwd=build_output_dir,
-                    stderr=subprocess.STDOUT,
-                    encoding="utf-8",
-                )
-            assert "No module named 'pandas'" in exc.value.output
-
-        # rebuild with new deps
-        (tempdir_path / "dagster_project1/requirements.txt").write_text("pandas\n")
-        with run_builder(
-            builder_pex_path,
-            [
-                "-m",
-                "dagster_cloud_cli.core.pex_builder.deps",
-                str(tempdir_path / "dagster_project1"),
-            ],
-        ) as (build_output_dir, pex_files, other_files):
-
-            deps_file = pex_files[0]
-            output = subprocess.check_output(
-                ["./" + deps_file, str(import_pandas_code)],
-                cwd=build_output_dir,
-                stderr=subprocess.STDOUT,
-                encoding="utf-8",
-            )
-            assert "OK" in output
-
-
-@mock.patch("dagster_cloud_cli.core.pex_builder.deps.build_deps_from_requirements")
-@mock.patch("dagster_cloud_cli.core.pex_builder.source.build_source_pex")
-def test_builder_deploy_with_upload(
-    build_source_pex_mock,
-    build_deps_from_requirements_mock,
-    builder_module,
-    repo_root,
-    pex_registry_fixture,
-):
-    from dagster_cloud_cli.core.pex_builder import deploy
-
-    dagster_project1_yaml = (
-        repo_root / "tests/test-repos/dagster_project1/dagster_cloud.yaml"
-    )
-
-    def build_deps_from_requirements(requirements, output_directory):
-        filepath = os.path.join(output_directory, deps_pex_content + ".pex")
-        with open(filepath, "w") as pex_file:
-            pex_file.write(deps_pex_content)
-        return filepath, "1.0.11"
-
-    build_deps_from_requirements_mock.side_effect = build_deps_from_requirements
-
-    def build_source_pex(code_directory, local_package_paths, output_directory, python_version):
-        filepath = os.path.join(output_directory, source_pex_content + ".pex")
-        with open(filepath, "w") as pex_file:
-            pex_file.write(source_pex_content)
-        return filepath
-
-    build_source_pex_mock.side_effect = build_source_pex
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # 1st deploy
-        deps_pex_content = "deps-pex-1"
-        source_pex_content = "source-pex-1"
-        location_builds = deploy.deploy_main(
-            str(dagster_project1_yaml),
-            temp_dir,
-            upload_pex=True,
-            deps_cache_from_tag=None,
-            deps_cache_to_tag=None,
-            update_code_location=False,
-            code_location_details=None,
-            python_version="3.8",
-            build_sdists=True,
-        )
-        # deps-HASH.pex, source-HASH.pex
-        assert set(pex_registry_fixture.keys()) == {
-            "deps-pex-1.pex",
-            "source-pex-1.pex",
-        }
-        assert pex_registry_fixture["deps-pex-1.pex"] == b"deps-pex-1"
-        assert len(location_builds) == 1
-        assert location_builds[0].pex_tag == "files=deps-pex-1.pex:source-pex-1.pex"
-
-        # 2nd deploy - same requirements but deps.pex is rebuilt since we dont have a cache tag
-        deps_pex_content = "deps-pex-2"
-        build_deps_from_requirements_mock.reset()
-        location_builds = deploy.deploy_main(
-            str(dagster_project1_yaml),
-            temp_dir,
-            upload_pex=True,
-            deps_cache_from_tag=None,
-            deps_cache_to_tag=None,
-            update_code_location=False,
-            code_location_details=None,
-            python_version="3.8",
-            build_sdists=True,
-        )
-        build_deps_from_requirements_mock.assert_called()
-        assert "deps-pex-2.pex" in pex_registry_fixture
-
-        # 3rd deploy with cache tag - deps.pex is rebuilt and associated with new cache tag
-        deps_pex_content = "deps-pex-3"
-        build_deps_from_requirements_mock.reset()
-        location_builds = deploy.deploy_main(
-            str(dagster_project1_yaml),
-            temp_dir,
-            upload_pex=True,
-            deps_cache_from_tag="tag1",
-            deps_cache_to_tag="tag1",
-            update_code_location=False,
-            code_location_details=None,
-            python_version="3.8",
-            build_sdists=True,
-        )
-        assert "deps-pex-3.pex" in pex_registry_fixture
-        assert location_builds[0].pex_tag == "files=deps-pex-3.pex:source-pex-1.pex"
-
-        # 4th deploy with same cache tag - deps.pex is not rebuilt but reused
-        deps_pex_content = "deps-pex-4"
-        location_builds = deploy.deploy_main(
-            str(dagster_project1_yaml),
-            temp_dir,
-            upload_pex=True,
-            deps_cache_from_tag="tag1",
-            deps_cache_to_tag="tag1",
-            update_code_location=False,
-            code_location_details=None,
-            python_version="3.8",
-            build_sdists=True,
-        )
-        assert "deps-pex-4.pex" not in pex_registry_fixture
-        assert location_builds[0].pex_tag == "files=deps-pex-3.pex:source-pex-1.pex"
-
-        # 5th deploy with only write tag - deps.pex is rebuilt, even though cache tag exists
-
-        deps_pex_content = "deps-pex-5"
-        location_builds = deploy.deploy_main(
-            str(dagster_project1_yaml),
-            temp_dir,
-            upload_pex=True,
-            deps_cache_from_tag=None,
-            deps_cache_to_tag="tag1",
-            update_code_location=False,
-            code_location_details=None,
-            python_version="3.8",
-            build_sdists=True,
-        )
-        assert "deps-pex-5.pex" in pex_registry_fixture
-        assert location_builds[0].pex_tag == "files=deps-pex-5.pex:source-pex-1.pex"
-
-        # 6th deploy with different read and write tags - deps.pex is reused
-
-        deps_pex_content = "deps-pex-6"
-        location_builds = deploy.deploy_main(
-            str(dagster_project1_yaml),
-            temp_dir,
-            upload_pex=True,
-            deps_cache_from_tag="tag1",
-            deps_cache_to_tag="tag1-copy",
-            update_code_location=False,
-            code_location_details=None,
-            python_version="3.8",
-            build_sdists=True,
-        )
-        assert "deps-pex-6.pex" not in pex_registry_fixture
-        assert location_builds[0].pex_tag == "files=deps-pex-5.pex:source-pex-1.pex"
-
-        # 7th deploy wth the seeded cache tag - deps.pex is reused
-
-        deps_pex_content = "deps-pex-7"
-        location_builds = deploy.deploy_main(
-            str(dagster_project1_yaml),
-            temp_dir,
-            upload_pex=True,
-            deps_cache_from_tag="tag1-copy",
-            deps_cache_to_tag="tag1-copy",
-            update_code_location=False,
-            code_location_details=None,
-            python_version="3.8",
-            build_sdists=True,
-        )
-        print(pex_registry_fixture)
-        assert "deps-pex-7.pex" not in pex_registry_fixture
-        assert location_builds[0].pex_tag == "files=deps-pex-5.pex:source-pex-1.pex"
-
-
-def test_builder_selftest(builder_pex_path):
+def test_dagster_cloud_runnable(dagster_cloud_pex_path):
     output = subprocess.check_output(
-        [builder_pex_path, "-m", "builder.selftest"], encoding="utf-8"
+        [dagster_cloud_pex_path, "-c", "print('hello')"], encoding="utf-8"
     )
-    assert "hello from selftest.py" in output
+    assert "hello" in output


### PR DESCRIPTION
The main entrypoint for the script is:
```
python scripts/release.py 0.1.21 0.1.20
```
This builds and publishes the docker action, builds the dagster-cloud.pex file and replaces the references to the old version (that's why it accepts the `version_tag previous_version_tag` as arguments).

