### PR TITLE
Increase location-load-timeout in cloud action

### DIFF
--- a/gitlab/hybrid-ci.yml
+++ b/gitlab/hybrid-ci.yml
@@ -47,7 +47,7 @@ deploy-docker:
       --location-file dagster_cloud.yaml
       --location-name $DAGSTER_CLOUD_LOCATION_NAME
       --image $REGISTRY_URL:$CI_COMMIT_SHA
-      --location-load-timeout 600
+      --location-load-timeout 3600
       --agent-heartbeat-timeout 600
       --commit-hash $CI_COMMIT_SHA
       --git-url $CI_PROJECT_URL/-/commit/$CI_COMMIT_SHA
@@ -84,7 +84,7 @@ deploy-docker-branch:
       --location-file dagster_cloud.yaml
       --location-name $DAGSTER_CLOUD_LOCATION_NAME
       --image $REGISTRY_URL:$CI_COMMIT_SHA
-      --location-load-timeout 600
+      --location-load-timeout 3600
       --agent-heartbeat-timeout 600
       --commit-hash $CI_COMMIT_SHA
       --git-url $CI_PROJECT_URL/-/commit/$CI_COMMIT_SHA

--- a/gitlab/serverless-legacy-ci.yml
+++ b/gitlab/serverless-legacy-ci.yml
@@ -61,7 +61,7 @@ deploy-docker:
       --location-file dagster_cloud.yaml
       --location-name $DAGSTER_CLOUD_LOCATION_NAME
       --image $REGISTRY_URL:prod-$DAGSTER_CLOUD_LOCATION_NAME-$CI_COMMIT_SHA
-      --location-load-timeout 600
+      --location-load-timeout 3600
       --agent-heartbeat-timeout 600
       --commit-hash $CI_COMMIT_SHA
       --git-url $CI_PROJECT_URL/-/commit/$CI_COMMIT_SHA
@@ -99,7 +99,7 @@ deploy-docker-branch:
       --location-file dagster_cloud.yaml
       --location-name $DAGSTER_CLOUD_LOCATION_NAME
       --image $REGISTRY_URL:prod-$DAGSTER_CLOUD_LOCATION_NAME-$CI_COMMIT_SHA
-      --location-load-timeout 600
+      --location-load-timeout 3600
       --agent-heartbeat-timeout 600
       --commit-hash $CI_COMMIT_SHA
       --git-url $CI_PROJECT_URL/-/commit/$CI_COMMIT_SHA

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -129,7 +129,7 @@ if [[ -z $PR_STATUS || "$PR_STATUS" == "OPEN" ]]; then
         --location-file "${INPUT_LOCATION_FILE}" \
         --location-name "${INPUT_LOCATION_NAME}" \
         --image "${INPUT_REGISTRY}:${INPUT_IMAGE_TAG}" \
-        --location-load-timeout 600 \
+        --location-load-timeout 3600 \
         --agent-heartbeat-timeout $AGENT_HEARTBEAT_TIMEOUT \
         --git-url "$COMMIT_URL" \
         --commit-hash "$COMMIT_HASH"

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,5 +1,6 @@
-import pytest
 import json
+
+import pytest
 
 
 def test_deploy_full_deployment_github(tmp_path, exec_context, action_docker_image_id):
@@ -34,7 +35,7 @@ def test_deploy_full_deployment_github(tmp_path, exec_context, action_docker_ima
             "workspace add-location --url http://dagster.cloud/test/prod "
             "--api-token api-token --location-file some-location/dagster_cloud.yaml "
             "--location-name some-location --image some-location-registry:prod-some-location-sha "
-            "--location-load-timeout 600 --agent-heartbeat-timeout 90 "
+            "--location-load-timeout 3600 --agent-heartbeat-timeout 90 "
             "--git-url https://github.com//some-org/some-project/tree/sha12345 "
             "--commit-hash sha12345": "",
         },
@@ -75,7 +76,7 @@ def test_deploy_full_deployment_gitlab(exec_context, action_docker_image_id, tmp
             "workspace add-location --url http://dagster.cloud/test/prod "
             "--api-token api-token --location-file some-location/dagster_cloud.yaml "
             "--location-name some-location --image some-location-registry:prod-some-location-sha "
-            "--location-load-timeout 600 --agent-heartbeat-timeout 90 "
+            "--location-load-timeout 3600 --agent-heartbeat-timeout 90 "
             "--git-url https://gitlab.com/some-org/some-project//-/commit/sha12345 "
             "--commit-hash sha12345": "",
         },


### PR DESCRIPTION
Summary:
This is currently set to 10 minutes, which is typically plenty - but can be exceeded in certain situations (ECS plus a slow code location load). It's also not clear whether this particular timeout is giving us any benefit in practice - the agent will almost always either be a) down, in which case the heartbeat timeout will kick in or b) will have its own timeout on the agent side that will move the location into an error state. So there's not much downside in increasing this.

Test Plan:
Rebuild and point an action at the new image, verify that when there's an error the github action still errors without timing out.
