### PR TITLE
Implement a prerun step that cleans up closed PRs

### DIFF
--- a/actions/utils/cleanup_closed_pr/action.yml
+++ b/actions/utils/cleanup_closed_pr/action.yml
@@ -9,9 +9,17 @@ runs:
   using: "composite"
   steps:
     - if: ${{ github.event.pull_request.state == 'closed' }}
-      run: "echo closed"
+      run: >
+        echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR" &&
+        $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment
+      shell: bash
+
+    - if: ${{ github.event.pull_request.state == 'closed' && input.exit_on_cleanup != 'true' }}
+      run: >
+        echo "::notice title=Closed Pull Request::Returning failure to cancel the rest of this workflow" && 
+        exit 1
       shell: bash
 
     - if: ${{ github.event.pull_request.state != 'closed' }}
-      run: "echo 'Not a PR or PR not closed'"
+      run: echo 'PR not closed (or not in a PR)'
       shell: bash

--- a/actions/utils/cleanup_closed_pr/action.yml
+++ b/actions/utils/cleanup_closed_pr/action.yml
@@ -13,5 +13,5 @@ runs:
       shell: bash
 
     - if: ${{ github.event.pull_request.state != 'closed' }}
-      run: "echo 'Not a PR or PR not closed"
+      run: "echo 'Not a PR or PR not closed'"
       shell: bash

--- a/actions/utils/cleanup_closed_pr/action.yml
+++ b/actions/utils/cleanup_closed_pr/action.yml
@@ -1,0 +1,15 @@
+name: "Cleanup for closed pull request"
+description: "If this pull request is closed, marks it closed in dagster-cloud."
+inputs:
+  exit_on_cleanup:
+    default: "true"
+    required: false
+    description: "If this pull request is closed, cancels workflow"
+runs:
+  using: "composite"
+  steps:
+    - if: ${{ github.event.pull_request.state == 'closed' }}
+      run: "echo closed"
+
+    - if: ${{ github.event.pull_request.state != 'closed' }}
+      run: "echo 'Not a PR or PR not closed"

--- a/actions/utils/cleanup_closed_pr/action.yml
+++ b/actions/utils/cleanup_closed_pr/action.yml
@@ -10,6 +10,8 @@ runs:
   steps:
     - if: ${{ github.event.pull_request.state == 'closed' }}
       run: "echo closed"
+      shell: bash
 
     - if: ${{ github.event.pull_request.state != 'closed' }}
       run: "echo 'Not a PR or PR not closed"
+      shell: bash

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -3,11 +3,17 @@ description: "Initialization and checks before running the deploy."
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.sha }}
+        path: prerun
+
     - name: Cleanup closed PR
       if: ${{ github.event.pull_request.state == 'closed' }}
       run: >
         echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, returning failure to cancel workflow" &&
-        $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment &&
+        $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun &&
         exit 1
       shell: bash
 

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -1,24 +1,13 @@
 name: "Prerun checks"
 description: "Initialization and checks before running the deploy."
-inputs:
-  cancel_when_pr_closed:
-    default: "true"
-    required: false
-    description: "If this pull request is closed, cancels workflow"
 runs:
   using: "composite"
   steps:
     - name: Cleanup closed PR
       if: ${{ github.event.pull_request.state == 'closed' }}
       run: >
-        echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR" &&
-        $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment
-      shell: bash
-
-    - name: Cancel workflow for closed PR
-      if: ${{ github.event.pull_request.state == 'closed' && input.exit_on_cleanup != 'true' }}
-      run: >
-        echo "::notice title=Closed Pull Request::Returning failure to cancel the rest of this workflow" && 
+        echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, returning failure to cancel workflow" &&
+        $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment &&
         exit 1
       shell: bash
 

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -1,20 +1,22 @@
-name: "Cleanup for closed pull request"
-description: "If this pull request is closed, marks it closed in dagster-cloud."
+name: "Prerun checks"
+description: "Initialization and checks before running the deploy."
 inputs:
-  exit_on_cleanup:
+  cancel_when_pr_closed:
     default: "true"
     required: false
     description: "If this pull request is closed, cancels workflow"
 runs:
   using: "composite"
   steps:
-    - if: ${{ github.event.pull_request.state == 'closed' }}
+    - name: Cleanup closed PR
+      if: ${{ github.event.pull_request.state == 'closed' }}
       run: >
         echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR" &&
         $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment
       shell: bash
 
-    - if: ${{ github.event.pull_request.state == 'closed' && input.exit_on_cleanup != 'true' }}
+    - name: Cancel workflow for closed PR
+      if: ${{ github.event.pull_request.state == 'closed' && input.exit_on_cleanup != 'true' }}
       run: >
         echo "::notice title=Closed Pull Request::Returning failure to cancel the rest of this workflow" && 
         exit 1

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -1,5 +1,10 @@
 name: "Prerun checks"
 description: "Initialization and checks before running the deploy."
+outputs:
+  result:
+    description: "May be 'skip', to indicate the rest of the workflow should be skipped"
+    value: ${{ steps.cleanup-closed-pr.outputs.result }}
+
 runs:
   using: "composite"
   steps:
@@ -10,13 +15,15 @@ runs:
         path: prerun
 
     - name: Cleanup closed PR
+      id: cleanup-closed-pr
       if: ${{ github.event.pull_request.state == 'closed' }}
       run: >
-        echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, returning failure to cancel workflow" &&
+        echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, will skip remaining workflow" &&
         $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun &&
-        exit 1
+        echo 'result=skip' >> $GITHUB_OUTPUT
       shell: bash
 
     - if: ${{ github.event.pull_request.state != 'closed' }}
       run: echo 'PR not closed (or not in a PR)'
       shell: bash
+


### PR DESCRIPTION
Implement a `prerun` action that will be injected as the first step in our workflows (deploy.yml and branch_deployments.yml). This action implements proper cleanup of closed PRs. The return value will be used to skip additional steps in the workflow.

Following this I want to add the `ci check` command here. Having a single prerun hook would make it easier to add more checks whenever needed.