### PR TITLE
Add prerun step to serverless default workflows

### DIFF
--- a/github/serverless/branch_deployments.yml
+++ b/github/serverless/branch_deployments.yml
@@ -17,24 +17,28 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
-    
+
     steps:
+      - name: Prerun checks
+        id: prerun
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
+
       - name: Parse cloud workspace
-        if: env.ENABLE_FAST_DEPLOYS != 'true'
+        if: steps.prerun.outputs.result != 'skip' && env.ENABLE_FAST_DEPLOYS != 'true'
         id: parse-workspace
         uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
         with:
           dagster_cloud_file: dagster_cloud.yaml
 
       - name: Checkout
-        if: env.ENABLE_FAST_DEPLOYS == 'true'
+        if: steps.prerun.outputs.result != 'skip' && env.ENABLE_FAST_DEPLOYS == 'true'
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
           
       - name: Build and deploy Python executable
-        if: env.ENABLE_FAST_DEPLOYS == 'true'
+        if: steps.prerun.outputs.result != 'skip' && env.ENABLE_FAST_DEPLOYS == 'true'
         uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@pex-v0.1
         with:
           dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/dagster_cloud.yaml"

--- a/github/serverless/deploy.yml
+++ b/github/serverless/deploy.yml
@@ -19,24 +19,28 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
-    
+
     steps:
+      - name: Prerun checks
+        id: prerun
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
+
       - name: Parse cloud workspace
-        if: env.ENABLE_FAST_DEPLOYS != 'true'
+        if: steps.prerun.outputs.result != 'skip' && env.ENABLE_FAST_DEPLOYS != 'true'
         id: parse-workspace
         uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
         with:
           dagster_cloud_file: dagster_cloud.yaml
 
       - name: Checkout
-        if: env.ENABLE_FAST_DEPLOYS == 'true'
+        if: steps.prerun.outputs.result != 'skip' && env.ENABLE_FAST_DEPLOYS == 'true'
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
           
       - name: Build and deploy Python executable
-        if: env.ENABLE_FAST_DEPLOYS == 'true'
+        if: steps.prerun.outputs.result != 'skip' && env.ENABLE_FAST_DEPLOYS == 'true'
         uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@pex-v0.1
         with:
           dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/dagster_cloud.yaml"


### PR DESCRIPTION
This goes live as soon as merged so I'm going to test thoroughly before committing. 

Wanted to get feedback on how the prerun is used. The PR is one option where the prerun step returns `'skip'` or something else. Another option is to have the prerun one of `docker-deploy`, `pex-deploy` or `skip` and then and add simpler conditions like the following:

```yaml
      - name: Parse cloud workspace
        if: steps.prerun.outputs.result == 'docker-deploy'
        ...

      - name: Checkout
        if: steps.prerun.outputs.result == 'fast-deploy'
        ...

      - name: Build and deploy Python executable
        if: steps.prerun.outputs.result == 'fast-deploy'
        ...
``` 

Thoughts?