### PR TITLE
Export the branch deployment name output from the deploy action

### DIFF
--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -83,9 +83,6 @@ runs:
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
         
-    - name: Export BRANCH_DEPLOYMENT_NAME
-      run: echo BRANCH_DEPLOYMENT_NAME=${{ steps.deploy.outputs.deployment }} >> $GITHUB_ENV
-
     # Optional steps, leaves PR comment about build status
     - name: Notify build success
       uses: ./action-repo/actions/utils/notify

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -14,6 +14,11 @@ inputs:
     required: false
     description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
     default: 'true'
+outputs:
+  deployment:
+    description: "Name of the branch deployment for this PR"
+    value: ${{ steps.deploy.outputs.deployment }}
+
   # Build, push, deploy each location
 runs:
   using: "composite"

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -93,8 +93,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         
-    
-
     - name: Notify build failure
       if: ${{ failure() }}
       uses: ./action-repo/actions/utils/notify

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -97,7 +97,7 @@ runs:
         deployment: ${{ steps.deploy.outputs.deployment }}
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-        
+
     - name: Notify build failure
       if: ${{ failure() }}
       uses: ./action-repo/actions/utils/notify

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -82,7 +82,7 @@ runs:
         image_tag: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
-        
+
     # Optional steps, leaves PR comment about build status
     - name: Notify build success
       uses: ./action-repo/actions/utils/notify

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -77,6 +77,9 @@ runs:
         image_tag: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
+        
+    - name: Export BRANCH_DEPLOYMENT_NAME
+      run: echo BRANCH_DEPLOYMENT_NAME=${{ steps.deploy.outputs.deployment }} >> $GITHUB_ENV
 
     # Optional steps, leaves PR comment about build status
     - name: Notify build success
@@ -89,6 +92,8 @@ runs:
         deployment: ${{ steps.deploy.outputs.deployment }}
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        
+    
 
     - name: Notify build failure
       if: ${{ failure() }}

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -109,6 +109,9 @@ runs:
         registry: ${{ env.REGISTRY_URL }}
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
+        
+    - name: Export BRANCH_DEPLOYMENT_NAME
+      run: echo BRANCH_DEPLOYMENT_NAME=${{ steps.deploy.outputs.deployment }} >> $GITHUB_ENV
 
     # Optional steps, leaves PR comment about build status
     - name: Notify build success

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -20,6 +20,11 @@ inputs:
     required: false
     description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
     default: 'true'
+outputs:
+  deployment:
+    description: "Name of the branch deployment for this PR"
+    value: ${{ steps.deploy.outputs.deployment }}
+    
 runs:
   using: "composite"
   steps:
@@ -109,9 +114,6 @@ runs:
         registry: ${{ env.REGISTRY_URL }}
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
-        
-    - name: Export BRANCH_DEPLOYMENT_NAME
-      run: echo BRANCH_DEPLOYMENT_NAME=${{ steps.deploy.outputs.deployment }} >> $GITHUB_ENV
 
     # Optional steps, leaves PR comment about build status
     - name: Notify build success


### PR DESCRIPTION
Export an output called `deployment` from the deploy action. This is set to the branch deployment name in PRs.
Tested manually.