### PR TITLE
Update prerun to return the name of the closed_branch_deployment

### DIFF
--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -27,7 +27,7 @@ runs:
       run: >
         echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, will skip remaining workflow" &&
         $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun_checkout_dir > /tmp/closed-branch-deployment.txt &&
-        echo "closed_branch_deployment=$(cat /tmp/closed-branch-deployment.txt)" >> $GITHUB_OUTPUT
+        echo "closed_branch_deployment=$(cat /tmp/closed-branch-deployment.txt)" >> $GITHUB_OUTPUT &&
         echo 'result=skip' >> $GITHUB_OUTPUT
       shell: bash
 

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -26,8 +26,8 @@ runs:
       # closed PRs, this marks the pr_status=closed and attaches the merge commit details. 
       run: >
         echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, will skip remaining workflow" &&
-        echo $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun_checkout_dir > /tmp/closed-branch-deployment.txt &&
-        echo "closed_branch_deployment=`cat /tmp/closed-branch-deployment.txt`" >> $GITHUB_OUTPUT
+        $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun_checkout_dir > /tmp/closed-branch-deployment.txt &&
+        echo "closed_branch_deployment=$(cat /tmp/closed-branch-deployment.txt)" >> $GITHUB_OUTPUT
         echo 'result=skip' >> $GITHUB_OUTPUT
       shell: bash
 

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -27,7 +27,7 @@ runs:
       run: >
         echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, will skip remaining workflow" &&
         echo $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun_checkout_dir > /tmp/closed-branch-deployment.txt &&
-        echo "closed_branch_deployment=`cat /tmp/closed-branch-deployment.txt` >> $GITHUB_OUTPUT
+        echo "closed_branch_deployment=`cat /tmp/closed-branch-deployment.txt`" >> $GITHUB_OUTPUT
         echo 'result=skip' >> $GITHUB_OUTPUT
       shell: bash
 

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -4,6 +4,9 @@ outputs:
   result:
     description: "May be 'skip', to indicate the rest of the workflow should be skipped"
     value: ${{ steps.cleanup-closed-pr.outputs.result || steps.check-deployment-type.outputs.result}}
+  closed_branch_deployment:
+    description: "If this action closed a branch deployment, this field is set to the branch deployment name."
+    value: ${{ steps.cleanup-closed-pr.outputs.closed_branch_deployment }} 
 
 runs:
   using: "composite"
@@ -23,7 +26,8 @@ runs:
       # closed PRs, this marks the pr_status=closed and attaches the merge commit details. 
       run: >
         echo "::notice title=Closed Pull Request::Marking branch deployment closed for this PR, will skip remaining workflow" &&
-        $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun_checkout_dir &&
+        echo $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ci branch-deployment prerun_checkout_dir > /tmp/closed-branch-deployment.txt &&
+        echo "closed_branch_deployment=`cat /tmp/closed-branch-deployment.txt` >> $GITHUB_OUTPUT
         echo 'result=skip' >> $GITHUB_OUTPUT
       shell: bash
 


### PR DESCRIPTION
This is useful when users whan to run some cleanup step in their warehouse that needs the branch deployment name.