### PR TITLE
[dbt nux] Revert dagster project name

### DIFF
--- a/github/serverless/dbt/branch_deployments.yml
+++ b/github/serverless/dbt/branch_deployments.yml
@@ -54,7 +54,7 @@ jobs:
           rm ${{ env.DBT_PACKAGE_DATA_DIR }}/target/partial_parse.msgpack
         shell: bash
         env:
-          DAGSTER_PROJECT_NAME: ${{ secrets.DAGSTER_DBT_LOCATION_NAME }}
+          DAGSTER_PROJECT_NAME: 'dagster_dbt_scaffold'
           DBT_PROJECT_DIR: "$GITHUB_WORKSPACE/project-repo"
           DBT_PACKAGE_DATA_DIR: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_PROJECT_NAME/dbt-project"
 

--- a/github/serverless/dbt/deploy.yml
+++ b/github/serverless/dbt/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           rm ${{ env.DBT_PACKAGE_DATA_DIR }}/target/partial_parse.msgpack
         shell: bash
         env:
-          DAGSTER_PROJECT_NAME: ${{ secrets.DAGSTER_DBT_LOCATION_NAME }}
+          DAGSTER_PROJECT_NAME: 'dagster_dbt_scaffold'
           DBT_PROJECT_DIR: "$GITHUB_WORKSPACE/project-repo"
           DBT_PACKAGE_DATA_DIR: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_PROJECT_NAME/dbt-project"
 


### PR DESCRIPTION
The NUX clones this repository (dagster-cloud-action) to fetch the workflow files, but the cloud push that uses updated logic to handle the new dagster project names has not occurred yet, so github action runs on the live NUX are currently broken.