### PR TITLE
Allow a full deployment not called 'prod' for pex deploys

### DIFF
--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -65,6 +65,7 @@ runs:
     - if: ${{ inputs.deploy == 'true' }}
       run: >
         cd $ACTION_REPO &&
+        INPUT_DEPLOYMENT=${{ inputs.deployment }}
         /usr/bin/python src/deploy_pex.py
         ${{ inputs.dagster_cloud_file }}
         --python-version=${{ inputs.python_version }}

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Python version string, major.minor only, eg "3.8"'
     required: false
     default: '3.8'
+  deployment:
+    required: false
+    description: "The deployment to push to, defaults to 'prod'. Ignored for pull requests where the branch deployment is used."
+    default: "prod"  
   deploy:
     description: 'Whether to upload the code files and update the code location'
     required: false

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -34,7 +34,8 @@ def main():
         deployment_name = get_branch_deployment_name(project_dir)
     else:
         print("Going to do a full deployment.", flush=True)
-        deployment_name = os.getenv("DAGSTER_CLOUD_DEPLOYMENT", "prod")
+        # INPUT_DEPLOYMENT is automatically set by github to the `deployment:` input value, if provided
+        deployment_name = os.getenv("INPUT_DEPLOYMENT", "prod")
 
     ubuntu_version = get_runner_ubuntu_version()
     print("Running on Ubuntu", ubuntu_version, flush=True)

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -34,7 +34,7 @@ def main():
         deployment_name = get_branch_deployment_name(project_dir)
     else:
         print("Going to do a full deployment.", flush=True)
-        deployment_name = None
+        deployment_name = os.getenv("DAGSTER_CLOUD_DEPLOYMENT", "prod")
 
     ubuntu_version = get_runner_ubuntu_version()
     print("Running on Ubuntu", ubuntu_version, flush=True)

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -33,7 +33,7 @@ def main():
         project_dir = os.path.dirname(dagster_cloud_yaml)
         deployment_name = get_branch_deployment_name(project_dir)
     else:
-        # INPUT_DEPLOYMENT is automatically set by github to the `deployment:` input value, if provided
+        # INPUT_DEPLOYMENT is to the `deployment:` input value in action.yml
         deployment_name = os.getenv("INPUT_DEPLOYMENT", "prod")
         print(f"Deploying to a full deployment: {deployment_name}", flush=True)
 

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -33,9 +33,9 @@ def main():
         project_dir = os.path.dirname(dagster_cloud_yaml)
         deployment_name = get_branch_deployment_name(project_dir)
     else:
-        print("Going to do a full deployment.", flush=True)
         # INPUT_DEPLOYMENT is automatically set by github to the `deployment:` input value, if provided
         deployment_name = os.getenv("INPUT_DEPLOYMENT", "prod")
+        print(f"Deploying to a full deployment: {deployment_name}", flush=True)
 
     ubuntu_version = get_runner_ubuntu_version()
     print("Running on Ubuntu", ubuntu_version, flush=True)


### PR DESCRIPTION
The default deployment name can be overridden using the `deployment:` input to the action. Eg

<img width="620" alt="image" src="https://github.com/dagster-io/dagster-cloud-action/assets/7066873/d21ee1e3-0aeb-4a99-b087-d986f79a82f7">

## Test Plan
Rename a deployment to something other than `prod`
Point the `build_deploy_python_executable` action in `deploy.yml` to this branch and add the `deployment:` input
Verify that the workflow deployment works
Rename deployment back to `prod`
Verify that workflow deployment fails
Remove `deployment:` input
Verify that the workflow deployment works again

Ran all above steps in a test org successfully. 