### PR TITLE
Release 0.1.37 - link to changed assets for branch deployment

### DIFF
--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.31"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.37"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.31"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.37"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/get_branch_deployment/action.yml
+++ b/actions/utils/get_branch_deployment/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.31"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.37"
   entrypoint: "/get_branch_deployment.sh"

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.31"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.37"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.31"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.37"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.31"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.37"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/gitlab/dbt/serverless-ci-dbt.yml
+++ b/gitlab/dbt/serverless-ci-dbt.yml
@@ -10,7 +10,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -49,7 +49,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   when: manual
   only:
     - merge_requests
@@ -74,7 +74,7 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     # install dbt package
     - pip install pip --upgrade

--- a/gitlab/hybrid-ci.yml
+++ b/gitlab/hybrid-ci.yml
@@ -29,7 +29,7 @@ workflow:
 
 initialize:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     - export
     - dagster-cloud ci check --project-dir=$DAGSTER_PROJECT_DIR --dagster-cloud-yaml-path=$DAGSTER_CLOUD_YAML_PATH
@@ -75,7 +75,7 @@ deploy-docker:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -87,7 +87,7 @@ deploy-docker-branch:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -97,7 +97,7 @@ deploy-docker-branch:
 
 close-branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   when: manual
   only:
     - merge_requests

--- a/gitlab/serverless-ci.yml
+++ b/gitlab/serverless-ci.yml
@@ -7,7 +7,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -35,7 +35,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   when: manual
   only:
     - merge_requests
@@ -60,6 +60,6 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     - /gitlab_action/deploy.py ./dagster_cloud.yaml

--- a/gitlab/serverless-legacy-ci.yml
+++ b/gitlab/serverless-legacy-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     - python /gitlab_action/parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -23,7 +23,7 @@ parse-workspace:
 
 fetch-registry-info:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script: dagster-cloud serverless registry-info --url $DAGSTER_CLOUD_URL/prod --api-token $DAGSTER_CLOUD_API_TOKEN | grep '=' >> registry.env
   artifacts:
     reports:
@@ -53,7 +53,7 @@ deploy-docker:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL/prod
@@ -74,7 +74,7 @@ deploy-docker-branch:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -109,7 +109,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.31
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.37
   when: manual
   only:
     - merge_requests

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -114,7 +114,7 @@ def update_dagster_cloud_pex(
         "-o=dagster-cloud.pex",
         "--platform=manylinux2014_x86_64-cp-38-cp38",
         "--platform=macosx_12_0_x86_64-cp-38-cp38",
-        "--platform=macosx_12_0_arm64-cp-38-cp38",
+        # "--platform=macosx_12_0_arm64-cp-38-cp38",
         "--pip-version=23.0",
         "--resolver-version=pip-2020-resolver",
         "--venv=prepend",

--- a/src/create_or_update_comment.py
+++ b/src/create_or_update_comment.py
@@ -49,7 +49,7 @@ def main():
             break
 
     deployment_url = f"{org_url}/{deployment_name}/home"
-    changed_assets_url = f"{deployment_url}/asset-groups?changedInBranch=%5B%22CODE_VERSION%22%2C%22INPUTS%22%2C%22NEW%22%2C%22PARTITIONS_DEFINITION%22%5D"
+    changed_assets_url = f"{org_url}/{deployment_name}/asset-groups?changedInBranch=%5B%22CODE_VERSION%22%2C%22INPUTS%22%2C%22NEW%22%2C%22PARTITIONS_DEFINITION%22%5D"
 
     message = f"[View in Cloud]({deployment_url})"
     changed_assets_message = f"[View Changed Assets]({changed_assets_url})"
@@ -71,8 +71,8 @@ def main():
     message = f"""
 Your pull request is automatically being deployed to Dagster Cloud.
 
-| Location          | Status          | Link    | Jump to Changed Assets      | Updated         |
-| ----------------- | --------------- | ------- | --------------------------- | --------------- |
+| Location          | Status          | Link      | Changed Assets           | Updated         |
+| ----------------- | --------------- | --------- | ------------------------ | --------------- |
 | `{location_name}` | {status_image}  | {message} | {changed_assets_message} | {time_str}      |
     """
 

--- a/src/create_or_update_comment.py
+++ b/src/create_or_update_comment.py
@@ -49,15 +49,19 @@ def main():
             break
 
     deployment_url = f"{org_url}/{deployment_name}/home"
+    changed_assets_url = f"{deployment_url}/asset-groups?changedInBranch=%5B%22CODE_VERSION%22%2C%22INPUTS%22%2C%22NEW%22%2C%22PARTITIONS_DEFINITION%22%5D"
 
     message = f"[View in Cloud]({deployment_url})"
+    changed_assets_message = f"[View Changed Assets]({changed_assets_url})"
     image_url = SUCCESS_IMAGE_URL
 
     if action == "pending":
         message = f"[Building...]({github_run_url})"
+        changed_assets_message = message
         image_url = PENDING_IMAGE_URL
     elif action == "failed":
         message = f"[Deploy failed]({github_run_url})"
+        changed_assets_message = message
         image_url = FAILED_IMAGE_URL
 
     status_image = f'[<img src="{image_url}" width=25 height=25/>]({github_run_url})'
@@ -67,9 +71,9 @@ def main():
     message = f"""
 Your pull request is automatically being deployed to Dagster Cloud.
 
-| Location          | Status          | Link    | Updated         |
-| ----------------- | --------------- | ------- | --------------- | 
-| `{location_name}` | {status_image}  | {message}  | {time_str}      |
+| Location          | Status          | Link    | Jump to Changed Assets      | Updated         |
+| ----------------- | --------------- | ------- | --------------------------- | --------------- |
+| `{location_name}` | {status_image}  | {message} | {changed_assets_message} | {time_str}      |
     """
 
     if comment_to_update:


### PR DESCRIPTION
Adds a column to the branch deployment comment with a link to the changed assets for a particular PR.

You can see the comment in this PR! and here https://github.com/dagster-io/dagster-cloud-action-test/pull/38 but my test PR to update Purina isn't showing the new column https://github.com/dagster-io/internal/pull/9141 which is confusing and i need to investigate