### PR TITLE
Install setuptools since 3.12 doesn't do it by default

### DIFF
--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -57,6 +57,7 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
+      run: pip install setuptools
 
     - run: >
         echo SOURCE_DIRECTORY=$(dirname ${{ inputs.dagster_cloud_file }}) >> $GITHUB_ENV


### PR DESCRIPTION
The user specified python environment is used to run the users `setup.py`. For 3.12 and newer setuptools is not packaged by default but it is required for setup.py. This should be a no-op for 3.11 and older.