### PR TITLE
Explicitly spell out that all paths will trigger branch deployment action

### DIFF
--- a/.github/workflows/hybrid_branch_deployments.yml
+++ b/.github/workflows/hybrid_branch_deployments.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           filters: |
             workspace:
-              - "**"
+              - "**" # Default to deploying on any change. Change this to limit what triggers branch deployments
 
   parse_workspace:
     needs: check_paths

--- a/.github/workflows/hybrid_branch_deployments.yml
+++ b/.github/workflows/hybrid_branch_deployments.yml
@@ -2,11 +2,28 @@ name: Hybrid Branch Deployments
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths: # Default to deploying on any change. Change this to limit what triggers branch deployments
+      - "**"
 env:
   DAGSTER_CLOUD_URL: "https://action-demo-hybrid.dogfood.dagster.cloud"
 
 jobs:
+  check_paths:
+    runs-on: ubuntu-20.04
+    outputs:
+      workspace_changed: ${{ steps.filter.outputs.workspace }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            workspace:
+              - "**"
+
   parse_workspace:
+    needs: check_paths
+    if: needs.check_paths.outputs.workspace_changed == 'true'
     runs-on: ubuntu-latest
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}

--- a/.github/workflows/serverless_branch_custom_base_image.yml
+++ b/.github/workflows/serverless_branch_custom_base_image.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           filters: |
             workspace:
-              - "**"
+              - "**" # Default to deploying on any change. Change this to limit what triggers branch deployments
   parse_workspace:
     needs: check_paths
     if: needs.check_paths.outputs.workspace_changed == 'true'

--- a/.github/workflows/serverless_branch_custom_base_image.yml
+++ b/.github/workflows/serverless_branch_custom_base_image.yml
@@ -2,11 +2,27 @@ name: Serverless Branch Deployments
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths: # Default to deploying on any change. Change this to limit what triggers branch deployments
+      - "**"
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_SERVERLESS_URL }}
 
 jobs:
+  check_paths:
+    runs-on: ubuntu-20.04
+    outputs:
+      workspace_changed: ${{ steps.filter.outputs.workspace }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            workspace:
+              - "**"
   parse_workspace:
+    needs: check_paths
+    if: needs.check_paths.outputs.workspace_changed == 'true'
     runs-on: ubuntu-latest
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}

--- a/.github/workflows/serverless_branch_deployments.yml
+++ b/.github/workflows/serverless_branch_deployments.yml
@@ -18,8 +18,8 @@ jobs:
         id: filter
         with:
           filters: |
-            workspace:
-              - "**"
+            workspace: 
+              - "**"  # Default to deploying on any change. Change this to limit what triggers branch deployments
   parse_workspace:
     needs: check_paths
     if: needs.check_paths.outputs.workspace_changed == 'true'

--- a/.github/workflows/serverless_branch_deployments.yml
+++ b/.github/workflows/serverless_branch_deployments.yml
@@ -2,11 +2,27 @@ name: Serverless Branch Deployments
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths: # Default to deploying on any change. Change this to limit what triggers branch deployments
+      - "**"
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_SERVERLESS_URL }}
 
 jobs:
+  check_paths:
+    runs-on: ubuntu-20.04
+    outputs:
+      workspace_changed: ${{ steps.filter.outputs.workspace }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            workspace:
+              - "**"
   parse_workspace:
+    needs: check_paths
+    if: needs.check_paths.outputs.workspace_changed == 'true'
     runs-on: ubuntu-latest
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}

--- a/github/serverless/branch_deployments.yml
+++ b/github/serverless/branch_deployments.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           filters: |
             workspace:
-              - "**"
+              - "**" # Default to deploying on any change. Change this to limit what triggers branch deployments
   dagster_cloud_default_deploy:
     name: Dagster Serverless Deploy
     needs: check_paths

--- a/github/serverless/branch_deployments.yml
+++ b/github/serverless/branch_deployments.yml
@@ -2,6 +2,8 @@ name: Serverless Branch Deployments
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths: # Default to deploying on any change. Change this to limit what triggers branch deployments
+      - "**"
     
 concurrency:
   # Cancel in-progress deploys to same branch
@@ -15,8 +17,22 @@ env:
   DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
 
 jobs:
+  check_paths:
+    runs-on: ubuntu-20.04
+    outputs:
+      workspace_changed: ${{ steps.filter.outputs.workspace }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            workspace:
+              - "**"
   dagster_cloud_default_deploy:
     name: Dagster Serverless Deploy
+    needs: check_paths
+    if: needs.check_paths.outputs.workspace_changed == 'true'
     runs-on: ubuntu-20.04
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}

--- a/github/serverless/dbt/branch_deployments.yml
+++ b/github/serverless/dbt/branch_deployments.yml
@@ -2,6 +2,8 @@ name: Serverless Branch Deployments
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths: # Default to deploying on any change. Change this to limit what triggers branch deployments
+      - "**"
 
 concurrency:
   # Cancel in-progress deploys to same branch
@@ -17,7 +19,21 @@ env:
   DAGSTER_PROJECT_NAME: 'dagster_dbt_scaffold'
 
 jobs:
+  check_paths:
+    runs-on: ubuntu-20.04
+    outputs:
+      workspace_changed: ${{ steps.filter.outputs.workspace }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            workspace:
+              - "**"
   dagster_cloud_default_deploy:
+    needs: check_paths
+    if: needs.check_paths.outputs.workspace_changed == 'true'
     name: Dagster Serverless Deploy
     runs-on: ubuntu-20.04
     outputs:

--- a/github/serverless/dbt/branch_deployments.yml
+++ b/github/serverless/dbt/branch_deployments.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           filters: |
             workspace:
-              - "**"
+              - "**" # Default to deploying on any change. Change this to limit what triggers branch deployments
   dagster_cloud_default_deploy:
     needs: check_paths
     if: needs.check_paths.outputs.workspace_changed == 'true'


### PR DESCRIPTION
1. Updating our actions to specify that all paths will trigger the action. 
2. Adding a filter step that helps avoid the issue described in [this issue](https://linear.app/dagster-labs/issue/PLUS-1030/make-our-github-action-templates-play-nice-with-pull-request). TLDR: rebase commits end up re-triggering actions even if the PR being rebased didn't change the specified paths.

This should help our users not run into the same issue we ran into. 

One thing that is not good about this approach is that the `check_paths` step runs no matter what. Ideally we could skip it in the default case of "**" (all paths) triggering the action.