### PR TITLE
Use github.head_ref in ci init if the event is a PR

### DIFF
--- a/actions/utils/ci-init/action.yml
+++ b/actions/utils/ci-init/action.yml
@@ -38,8 +38,8 @@ runs:
         --dagster-cloud-yaml-path=${{ inputs.dagster_cloud_yaml_path }}
         --deployment=${{ inputs.deployment }}
         --status-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        --git-url=${{ github.server_url }}/${{ github.repository }}/tree/${{ github.sha }}
-        --commit-hash=${{ github.sha }}
+        --git-url=${{ github.server_url }}/${{ github.repository }}/tree/${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        --commit-hash=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         $LOCATION_NAMES_FLAG
       shell: bash
 


### PR DESCRIPTION
This PR changes the commit hash used by `ci-init` to use `github.head_ref` instead of `github.sha`.

`github.sha` on a PR event returns the merged commit sha of the default branch merged with the head commit of the PR's branch. This merge commit does not actually exist, so whenever a user clicks the git url on the Dagster Cloud Code Location page, it fails.

Example:
![Screenshot 2024-04-18 at 14 07 47](https://github.com/dagster-io/dagster-cloud-action/assets/3394986/0a648a73-9308-4729-8cdc-afc638e3ae00)

Instead, I think the behavior should be to go to the head commit of the PR's branch.

