### PR TITLE
Release 0.1.40

### DIFF
--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.39"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.40"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.39"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.40"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/get_branch_deployment/action.yml
+++ b/actions/utils/get_branch_deployment/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.39"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.40"
   entrypoint: "/get_branch_deployment.sh"

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.39"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.40"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.39"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.40"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.39"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:0.1.40"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/gitlab/dbt/serverless-ci-dbt.yml
+++ b/gitlab/dbt/serverless-ci-dbt.yml
@@ -12,7 +12,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -51,7 +51,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   when: manual
   only:
     - merge_requests
@@ -76,7 +76,7 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     # install dbt package
     - pip install pip --upgrade

--- a/gitlab/hybrid-ci.yml
+++ b/gitlab/hybrid-ci.yml
@@ -29,7 +29,7 @@ workflow:
 
 initialize:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     - export
     - dagster-cloud ci check --project-dir=$DAGSTER_PROJECT_DIR --dagster-cloud-yaml-path=$DAGSTER_CLOUD_YAML_PATH
@@ -75,7 +75,7 @@ deploy-docker:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -87,7 +87,7 @@ deploy-docker-branch:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -97,7 +97,7 @@ deploy-docker-branch:
 
 close-branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   when: manual
   only:
     - merge_requests

--- a/gitlab/serverless-ci.yml
+++ b/gitlab/serverless-ci.yml
@@ -9,7 +9,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -37,7 +37,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   when: manual
   only:
     - merge_requests
@@ -62,6 +62,6 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     - /gitlab_action/deploy.py ./dagster_cloud.yaml

--- a/gitlab/serverless-legacy-ci.yml
+++ b/gitlab/serverless-legacy-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     - python /gitlab_action/parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -23,7 +23,7 @@ parse-workspace:
 
 fetch-registry-info:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script: dagster-cloud serverless registry-info --url $DAGSTER_CLOUD_URL/prod --api-token $DAGSTER_CLOUD_API_TOKEN | grep '=' >> registry.env
   artifacts:
     reports:
@@ -53,7 +53,7 @@ deploy-docker:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL/prod
@@ -74,7 +74,7 @@ deploy-docker-branch:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -109,7 +109,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.39
+  image: ghcr.io/dagster-io/dagster-cloud-action:0.1.40
   when: manual
   only:
     - merge_requests

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM --platform=linux/amd64 quay.io/pypa/manylinux2014_x86_64:latest
 
 # Install deps
 RUN apt update && apt install git -y

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 quay.io/pypa/manylinux2014_x86_64:latest
+FROM --platform=linux/amd64 python:3.8.16-slim
 
 # Install deps
 RUN apt update && apt install git -y

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,12 +1,18 @@
-FROM quay.io/pypa/manylinux2014_x86_64:latest
+# Use an official manylinux builder (https://github.com/pypa/manylinux#docker-images)
+FROM --platform=linux/amd64 quay.io/pypa/manylinux2014_x86_64:latest
+
+# Add all the relevant Python binaries to the PATH
+ENV PATH="/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
 
 # Install deps
-RUN apt update && apt install git -y
-RUN pip install pex
+RUN yum update && yum install -y git
 
+# Install pex
+RUN python3.8 -m pip install pex
+
+# Create virtual environment
 COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex
 RUN pex-tools dagster-cloud.pex venv /venv-dagster-cloud
-ENV PATH="/venv-dagster-cloud/bin:$PATH"
 
 # Copy all src scripts
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8.16-slim
+FROM quay.io/pypa/manylinux2014_x86_64:latest
 
 # Install deps
 RUN apt update && apt install git -y

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -9,7 +9,6 @@ RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud-cli
-RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud-cli
 
 # Create virtual environment using PEX
 COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,9 +18,9 @@ RUN yum update && yum install -y git
 # Install Dagster Cloud
 RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud
 RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud
-RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud
-RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud
-RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud
+#RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud
+#RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud
+#RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud
 
 
 # Create virtual environment
@@ -59,3 +59,4 @@ COPY src/gitlab_action gitlab_action
 
 # Use the venv python as the command
 # CMD venv-dagster-cloud/bin/python3
+CMD python3

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -8,11 +8,29 @@ ENV PATH="/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-
 RUN yum update && yum install -y git
 
 # Install pex
-RUN python3.8 -m pip install pex
+#RUN python3.8 -m pip install pex
+#RUN /opt/python/cp38-cp38/bin/python -m pip install pex
+#RUN /opt/python/cp39-cp39/bin/python -m pip install pex
+#RUN /opt/python/cp310-cp310/bin/python -m pip install pex
+#RUN /opt/python/cp311-cp311/bin/python -m pip install pex
+#RUN /opt/python/cp312-cp312/bin/python -m pip install pex
+
+# Install Dagster Cloud
+RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud
+RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud
+RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud
+RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud
+RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud
+
 
 # Create virtual environment
-COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex
-RUN pex-tools dagster-cloud.pex venv /venv-dagster-cloud
+#COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex
+#RUN pex-tools dagster-cloud.pex venv /venv-dagster-cloud
+#RUN PEX_TOOLS=1 /opt/python/cp38-cp38/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
+#RUN PEX_TOOLS=1 /opt/python/cp39-cp39/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
+#RUN PEX_TOOLS=1 /opt/python/cp310-cp310/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
+#RUN PEX_TOOLS=1 /opt/python/cp311-cp311/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
+#RUN PEX_TOOLS=1 /opt/python/cp312-cp312/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
 
 # Copy all src scripts
 
@@ -40,4 +58,4 @@ COPY src/get_branch_deployment.sh /get_branch_deployment.sh
 COPY src/gitlab_action gitlab_action
 
 # Use the venv python as the command
-CMD venv-dagster-cloud/bin/python3
+# CMD venv-dagster-cloud/bin/python3

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,36 +1,23 @@
 # Use an official manylinux builder (https://github.com/pypa/manylinux#docker-images)
 FROM --platform=linux/amd64 quay.io/pypa/manylinux2014_x86_64:latest
 
-# Add all the relevant Python binaries to the PATH
-ENV PATH="/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
-
 # Install deps
 RUN yum update && yum install -y git
+RUN /opt/python/cp38-cp38/bin/python -m pip install pex
 
-# Install pex
-#RUN python3.8 -m pip install pex
-#RUN /opt/python/cp38-cp38/bin/python -m pip install pex
-#RUN /opt/python/cp39-cp39/bin/python -m pip install pex
-#RUN /opt/python/cp310-cp310/bin/python -m pip install pex
-#RUN /opt/python/cp311-cp311/bin/python -m pip install pex
-#RUN /opt/python/cp312-cp312/bin/python -m pip install pex
+RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud-cli
+RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud-cli
+#RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud-cli
+#RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud-cli
+#RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud-cli
 
-# Install Dagster Cloud
-RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud
-RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud
-#RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud
-#RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud
-#RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud
+# Create virtual environment using PEX
+COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex
+RUN PEX_TOOLS=1 /opt/python/cp38-cp38/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
 
+# Add all the relevant Python binaries to the PATH
+ENV PATH="/venv-dagster-cloud/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
 
-# Create virtual environment
-#COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex
-#RUN pex-tools dagster-cloud.pex venv /venv-dagster-cloud
-#RUN PEX_TOOLS=1 /opt/python/cp38-cp38/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
-#RUN PEX_TOOLS=1 /opt/python/cp39-cp39/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
-#RUN PEX_TOOLS=1 /opt/python/cp310-cp310/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
-#RUN PEX_TOOLS=1 /opt/python/cp311-cp311/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
-#RUN PEX_TOOLS=1 /opt/python/cp312-cp312/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
 
 # Copy all src scripts
 
@@ -58,5 +45,4 @@ COPY src/get_branch_deployment.sh /get_branch_deployment.sh
 COPY src/gitlab_action gitlab_action
 
 # Use the venv python as the command
-# CMD venv-dagster-cloud/bin/python3
-CMD python3
+CMD venv-dagster-cloud/bin/python3

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,9 +7,9 @@ RUN /opt/python/cp38-cp38/bin/python -m pip install pex
 
 RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud-cli
-#RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud-cli
-#RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud-cli
-#RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud-cli
+RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud-cli
+RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud-cli
+RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud-cli
 
 # Create virtual environment using PEX
 COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex


### PR DESCRIPTION
Updates the base image for dagster-cloud-action. Now using [quay.io/pypa/manylinux2014_x86_64:latest](https://quay.io/repository/pypa/manylinux2014_x86_64?tab=tags&tag=latest) and supporting Python versions 3.8 to 3.11 when deploying to Dagster+.

Tested with GitLab in PR #174 
Tested with GitHub in https://github.com/maximearmstrong/with_openai
See successful runs with Python versions:
[3.8](https://github.com/maximearmstrong/with_openai/actions/runs/9132491998)
[3.9](https://github.com/maximearmstrong/with_openai/actions/runs/9132581817)
[3.10](https://github.com/maximearmstrong/with_openai/actions/runs/9132693314)
[3.11](https://github.com/maximearmstrong/with_openai/actions/runs/9132776183)