### PR TITLE
Update action.yml

### DIFF
--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.6
       with:
         # Checking out the commit sha should always work. For closed PRs with deleted branches,
         # this checks out the sha of the merge commit.


### PR DESCRIPTION
Updating the checkout action to the latest version.  This will resolve the following warning message after a successful run:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

reference to action: https://github.com/actions/checkout/tree/v4.1.4/