### PR TITLE
Fix incorrect comment in ci-init action

### DIFF
--- a/actions/utils/ci-init/action.yml
+++ b/actions/utils/ci-init/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: "dagster_cloud.yaml"
   deployment:
     required: false
-    description: "The deployment name to deploy. This value is ignored for pull requests."
+    description: "The deployment name to deploy. For pull requests, this deployment will be used as the base deployment."
     default: "prod"
   location_names:
     required: false
@@ -33,7 +33,7 @@ runs:
     # Initialize the build session
     - id: ci-init
       run: >
-        $DAGSTER_CLOUD_PEX -m dagster_cloud_cli.entrypoint ci init 
+        $DAGSTER_CLOUD_PEX -m dagster_cloud_cli.entrypoint ci init
         --project-dir=${{ inputs.project_dir }}
         --dagster-cloud-yaml-path=${{ inputs.dagster_cloud_yaml_path }}
         --deployment=${{ inputs.deployment }}


### PR DESCRIPTION
Summary:
deployment is used as the base deployment, it is no longer unused for pull requests.
