### PR TITLE
Update manylinux builder image

### DIFF
--- a/src/Dockerfile.dagster-manylinux-builder
+++ b/src/Dockerfile.dagster-manylinux-builder
@@ -1,7 +1,8 @@
 # Builds ghcr.io/daster-io/dagster-manylinux-builder:*
 
-# This docker image contains the PEX builder (builder.pex) and is capable of 
-# building source only dependencies (sdists) for Python that work with Dagster Cloud Serverless base
+# This docker image contains dagster-cloud and is capable of 
+# building source only dependencies (sdists) for Python that
+# work with Dagster Cloud Serverless base
 # images.
 
 # To publish a new version:
@@ -20,20 +21,15 @@
 # ---
 
 # Use an official manylinux builder (https://github.com/pypa/manylinux#docker-images)
-FROM --platform=linux/amd64 quay.io/pypa/manylinux2014_x86_64:latest
+FROM --platform=linux/amd64 quay.io/pypa/manylinux_2_28_x86_64:latest
 
 # Add all the relevant Python binaries to the PATH
-ENV PATH="/opt/python/cp38-cp38/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:$PATH"
+ENV PATH="/opt/python/cp38-cp38/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin/:/opt/python/cp312-cp312/bin/:$PATH"
 
 # To install unreleased versions, build the wheels and drop them in this directory
 COPY wheels /wheels
 
 # Install dagster-cloud
-RUN python3.8 -m pip install dagster-cloud --find-links file:///wheels/
+RUN python3.11 -m pip install dagster-cloud --find-links file:///wheels/
 
-COPY generated/gha/builder.pex /builder.pex
-
-# Run a selftest to ensure it works and also unpack the pex for faster startup
-RUN /builder.pex -m builder.selftest
-
-ENTRYPOINT /builder.pex
+ENTRYPOINT dagster-cloud


### PR DESCRIPTION
* Upgrade to a newer version of manylinux: manylinux_2_28_x86_64. The 2014 version is centos based which is deprecated
* Remove the obsolete builder.pex reference - only the dagster-cloud package is needed now

Test plan:
Tested locally to verify this can build and deploy a code location.
