### PR TITLE
Add base_image support to the serverless_prod_deploy action

### DIFF
--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -68,7 +68,7 @@ runs:
       with:
         target_directory: ${{ fromJson(inputs.location).directory }}
         env_vars: ${{ inputs.env_vars }}
-        base_image: ${{ inputs.base_image }}
+        base_image: ${{ inputs.base_image || fromJson(inputs.location).base_image }}
 
     - name: generate short github sha
       shell: bash

--- a/src/parse_workspace.py
+++ b/src/parse_workspace.py
@@ -17,7 +17,8 @@ def parse_workspace(dagster_cloud_file):
             "name": location["location_name"],
             "directory": location.get("build", {"directory": "."}).get("directory"),
             "build_folder": location.get("build", {"directory": "."}).get("directory"),
-            "registry": location.get("build", {"directory": "."}).get("registry"),
+            "registry": location.get("build", {}).get("registry"),
+            "base_image": location.get("build", {}).get("base_image"),
             "location_file": str(workspace),
         }
         for location in workspace_contents_yaml["locations"]


### PR DESCRIPTION
Summary:
Allows you to set build:base_image to vary the base image per code location.

Would like to port this to the new "dagster-cloud ci" commands as well.

Test Plan:
Build a release branch and test a build with and without the base_image set, in both a dagster_cloud.yaml file and in the action itself.
