### PR TITLE
Use correct command to upgrade pip in dbt nux

### DIFF
--- a/github/serverless/dbt/branch_deployments.yml
+++ b/github/serverless/dbt/branch_deployments.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.prerun.outputs.result == 'pex-deploy'
         # --upgrade-strategy eager picks up newer packages that are required for things to work
         run: |
-          pip install pip --upgrade
+          python -m pip install pip --upgrade
           cd project-repo/${{ env.DAGSTER_PROJECT_NAME }}
           pip install . --upgrade --upgrade-strategy eager
           dagster-dbt project prepare-and-package --file ${{ env.DAGSTER_PROJECT_NAME }}/project.py

--- a/github/serverless/dbt/deploy.yml
+++ b/github/serverless/dbt/deploy.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.prerun.outputs.result == 'pex-deploy'
         # --upgrade-strategy eager picks up newer packages that are required for things to work
         run: |
-          pip install pip --upgrade
+          python -m pip install pip --upgrade
           cd project-repo/${{ env.DAGSTER_PROJECT_NAME }}
           pip install . --upgrade --upgrade-strategy eager
           dagster-dbt project prepare-and-package --file ${{ env.DAGSTER_PROJECT_NAME }}/project.py


### PR DESCRIPTION
Summary:
The previous command did not actually upgrade pip and left us on 20.0.2.

Test Plan:
Go through the NUX with this new YAML, it now correctly backtracks and is able to install the correct set of dependencies.