### PR TITLE
Revert "Remove Python 3.12 support"

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -9,13 +9,14 @@ RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud-cli
+RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud-cli
 
 # Create virtual environment using PEX
 COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex
 RUN PEX_TOOLS=1 /opt/python/cp38-cp38/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
 
 # Add all the relevant Python binaries to the PATH
-ENV PATH="/venv-dagster-cloud/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:$PATH"
+ENV PATH="/venv-dagster-cloud/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
 
 
 # Copy all src scripts


### PR DESCRIPTION
Summary: This reverts commit 101fa9f3f9dee380cce9f516a687c503dfe7d120. We should be able to support 3.12 now, will verify via testing.
