### PR TITLE
Make deps.pex cache repo scoped, so PRs and main commits share deps.pex

### DIFF
--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -37,13 +37,11 @@ runs:
     - name: Set deps-cache-from
       # Don't use cached deps if instructed
       if: ${{ inputs.force_rebuild_deps != 'true' }}
-      # For PR commits, use the target branch name as the cache-tag, for other commits, use the branch name itself
-      run: echo "FLAG_DEPS_CACHE_FROM=--deps-cache-from=${{ github.repository }}/${{ github.ref_name }}" >> $GITHUB_ENV
+      run: echo "FLAG_DEPS_CACHE_FROM=--deps-cache-from=${{ github.repository }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Set deps-cache-to
-      # Only write to the cache-tag for non PR commits so PR commits don't upgrade dependency versions
-      run: echo "FLAG_DEPS_CACHE_TO=--deps-cache-to=${{ github.repository }}/${{ github.ref_name }}" >> $GITHUB_ENV
+      run: echo "FLAG_DEPS_CACHE_TO=--deps-cache-to=${{ github.repository }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Set up Python 3.8

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -43,7 +43,6 @@ runs:
 
     - name: Set deps-cache-to
       # Only write to the cache-tag for non PR commits so PR commits don't upgrade dependency versions
-      if: ${{ github.base_ref == '' }}
       run: echo "FLAG_DEPS_CACHE_TO=--deps-cache-to=${{ github.repository }}/${{ github.ref_name }}" >> $GITHUB_ENV
       shell: bash
 

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -38,7 +38,7 @@ runs:
       # Don't use cached deps if instructed
       if: ${{ inputs.force_rebuild_deps != 'true' }}
       # For PR commits, use the target branch name as the cache-tag, for other commits, use the branch name itself
-      run: echo "FLAG_DEPS_CACHE_FROM=--deps-cache-from=${{ github.repository }}/${{ github.base_ref && github.base_ref || github.ref_name }}" >> $GITHUB_ENV
+      run: echo "FLAG_DEPS_CACHE_FROM=--deps-cache-from=${{ github.repository }}/${{ github.ref_name }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Set deps-cache-to


### PR DESCRIPTION
Currently PRs can only reuse deps.pex if PRs do not change the dependencies. When dependencies are changed within a PR, the deps.pex is built every time. This is an optimization to let PRs build new deps.pex only once and then reuse it.