### PR TITLE
Remove error message recommending to disable fast deploys in GitHub actions

### DIFF
--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -46,7 +46,6 @@ def main():
     if returncode:
         print(
             "::error Title=Deploy failed::Failed to deploy Python Executable. "
-            "Try disabling fast deploys by setting `ENABLE_FAST_DEPLOYS: 'false'` in your .github/workflows/*yml."
         )
         # TODO: fallback to docker deploy here
         sys.exit(1)


### PR DESCRIPTION
Fixes [DS-190](https://linear.app/dagster-labs/issue/DS-190/remove-error-message-that-recommends-disabling-fast-deploys-in-github).

The message was confusing and misleading for some users.