### PR TITLE
Fix typo in serverless deploy yaml

### DIFF
--- a/github/serverless/dagster-plus-deploy.yml
+++ b/github/serverless/dagster-plus-deploy.yml
@@ -60,12 +60,12 @@ jobs:
       # First ensure the correct Python version is installed
       - name: Set up Python ${{ env.PYTHON_VERSION }} for target
         id: setup-python-version
-        if: steps.pre-run.outputs.result == 'pex-deploy'
+        if: steps.prerun.outputs.result == 'pex-deploy'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install setuptools
-        if: steps.pre-run.outputs.result == 'pex-deploy'
+        if: steps.prerun.outputs.result == 'pex-deploy'
         run: ${{ steps.setup-python-version.outputs.python-path }} -m pip install setuptools
         shell: bash
 


### PR DESCRIPTION
Summary:
The action in question is prerun not pre-run. This was breaking deploys to versions that were different than the one in the hosted pyenv.

Test Plan:
Deploy to 3.8 on 22.04, no more error abuot missing python 3.8
