### PR TITLE
Bring back --sh-boot to github action dagster cloud PEx

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -128,7 +128,7 @@ def build_dagster_cloud_pex(
         "--pip-version=23.0",
         "--resolver-version=pip-2020-resolver",
         "--venv=prepend",
-        "--python-shebang=/usr/bin/env python",
+        "--sh-boot",
         "-vvvvv",
     ]
     print(f"Running {args}")


### PR DESCRIPTION
Summary:
I believe after the test changes in https://github.com/dagster-io/dagster-cloud-action/pull/206 to no longer run the tests locally, it is safe (and more correct) to use this insteda of expecting python to be available at a particular path.
