### PR TITLE
Add run_id to Action Outputs

### DIFF
--- a/actions/utils/dagster-cloud-cli/action.yml
+++ b/actions/utils/dagster-cloud-cli/action.yml
@@ -5,9 +5,17 @@ inputs:
     required: true
     description: "The dagster-cloud cli command to run"
 
+outputs:
+  run_id:
+    description: "The run ID returned by the command"
+    value: ${{ steps.dagster-cloud-cli.outputs.run_id }}
+
 runs:
   using: "composite"
   steps:
     - id: dagster-cloud-cli
-      run: $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ${{ inputs.command }}
+      run: |
+        output=$($GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_cloud_cli.entrypoint ${{ inputs.command }})
+        echo "$output"
+        echo "run_id=$output" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
This change introduces a `run_id` output in the action metadata, making it accessible to subsequent steps in the workflow. The `run_id` value is derived from the output of the `dagster-cloud-cli` step, allowing workflows to reference it.