### PR TITLE
No longer build the github action using python 3.8

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -106,8 +106,8 @@ def build_dagster_cloud_pex(
 
     platform_args = []
 
-    # each of the default versions used by ubuntu 20.04 / 22.04 / 24.04 respectively
-    for py_version in ["38", "310", "312"]:
+    # each of the default versions used by ubuntu 22.04 / 24.04 respectively
+    for py_version in ["310", "312"]:
         platform_args.extend(
             [
                 f"--platform=manylinux2014_x86_64-cp-{py_version}-cp{py_version}",

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,9 +3,9 @@ FROM --platform=linux/amd64 quay.io/pypa/manylinux_2_28_x86_64:latest
 
 # Install deps
 RUN yum update -y & yum install -y git
-RUN /opt/python/cp38-cp38/bin/python -m pip install pex
+RUN /opt/python/cp311-cp311/bin/python -m pip install pex
 
-RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud-cli
+# RUN /opt/python/cp38-cp38/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp39-cp39/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp310-cp310/bin/python -m pip install dagster-cloud-cli
 RUN /opt/python/cp311-cp311/bin/python -m pip install dagster-cloud-cli
@@ -13,10 +13,10 @@ RUN /opt/python/cp312-cp312/bin/python -m pip install dagster-cloud-cli
 
 # Create virtual environment using PEX
 COPY generated/gha/dagster-cloud.pex /dagster-cloud.pex
-RUN PEX_TOOLS=1 /opt/python/cp38-cp38/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
+RUN PEX_TOOLS=1 /opt/python/cp311-cp311/bin/python /dagster-cloud.pex venv /venv-dagster-cloud
 
 # Add all the relevant Python binaries to the PATH
-ENV PATH="/venv-dagster-cloud/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
+ENV PATH="/venv-dagster-cloud/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
 
 
 # Copy all src scripts


### PR DESCRIPTION
Summary:
This is needed to be able to deploy newer versions of the dagster and dagster-cloud CLI.

Once we do this, we can no longer push to v0.1 or we may break users on python 3.8 / older versions. We need to move this action to a weekly release schedule anyway, so this is the opportunity to do that.
