### PR TITLE
fix get-branch-deployment action with a source_directory specified

### DIFF
--- a/src/get_branch_deployment.sh
+++ b/src/get_branch_deployment.sh
@@ -12,7 +12,8 @@ if [ -z $INPUT_SOURCE_DIRECTORY ]; then
     export INPUT_SOURCE_DIRECTORY=$(pwd)
 fi
 
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory $(realpath $INPUT_SOURCE_DIRECTORY)
+
 BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY)
 
 echo "deployment=${BRANCH_DEPLOYMENT_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
when you pass in a different source directory for the github repo we have to allow it or github will raise an error.

Test Plan:
Use this action with a source_directory, no more error