### PR TITLE
Change defaults build method for deploy_pex.py

### DIFF
--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -35,7 +35,7 @@ def main():
 
     ubuntu_version = get_runner_ubuntu_version()
     print("Running on Ubuntu", ubuntu_version, flush=True)
-    if ubuntu_version == "22.04":
+    if ubuntu_version == "22.04" or ubuntu_version == "20.04":
         returncode, output = deploy_pex(args, deployment_name, build_method="local")
     else:
         returncode, output = deploy_pex(args, deployment_name, build_method="docker")


### PR DESCRIPTION
ubuntu-20.04 is deprecated and we can now run wheels built on ubuntu-22.04 so we dont need the docker fallback for 22.04. But still need the fallback for 24.04