### PR TITLE
new init action that uses dg plus deploy and does not require a dagster_cloud.yaml

### DIFF
--- a/actions/utils/dg-cli/action.yml
+++ b/actions/utils/dg-cli/action.yml
@@ -1,0 +1,13 @@
+name: "dg cli <command>"
+description: "Run a dg cli command"
+inputs:
+  command:
+    required: true
+    description: "The dg cli command to run"
+
+runs:
+  using: "composite"
+  steps:
+    - id: dg-cli
+      run: $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_dg.cli.entrypoint ${{ inputs.command }}
+      shell: bash

--- a/actions/utils/dg-deploy-init/action.yaml
+++ b/actions/utils/dg-deploy-init/action.yaml
@@ -1,0 +1,49 @@
+name: "Initialize Deploy Session"
+description: "Initialize a new deploy session to Dagster+"
+inputs:
+  project_dir:
+    required: true
+    description: "The root directory of the dg project or workspace."
+  deployment:
+    required: false
+    description: "The deployment name to deploy. For pull requests, this deployment will be used as the base deployment."
+    default: "prod"
+  location_names:
+    required: false
+    description: "JSON list containing names of locations to deploy. If unspecified, all locations are deployed."
+
+runs:
+  using: "composite"
+  steps:
+    - name: init-env-vars
+      run: >
+        echo "DAGSTER_CLOUD_PEX=$GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex" >> $GITHUB_ENV &&
+        echo "DAGSTER_BUILD_STATEDIR=/tmp/statedir-$GITHUB_RUN_ID" >> $GITHUB_ENV
+      shell: bash
+
+    - name: set-location-names
+      if: ${{ inputs.location_names }}
+      run: echo ${{ format('LOCATION_NAMES_FLAG=--location-name={0}', join(fromJSON(inputs.location_names), ' --location-name=')) }} >> $GITHUB_ENV
+      shell: bash
+
+    # Initialize the deploy session
+    - id: start-deploy-session
+      run: >
+        $DAGSTER_CLOUD_PEX -m dagster_dg.cli.entrypoint plus deploy start
+        --path=${{ inputs.project_dir }}
+        --deployment=${{ inputs.deployment }}
+        --status-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        --git-url=${{ github.server_url }}/${{ github.repository }}/tree/${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        --commit-hash=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        --yes
+        $LOCATION_NAMES_FLAG
+      shell: bash
+
+    - id: ci-status
+      run: $DAGSTER_CLOUD_PEX -m dagster_cloud_cli.entrypoint ci status
+      shell: bash
+
+    # Create a PR comment if necessary
+    - id: ci-notify
+      run: $DAGSTER_CLOUD_PEX -m dagster_cloud_cli.entrypoint ci notify --project-dir=${{ inputs.project_dir }}
+      shell: bash


### PR DESCRIPTION
Summary:
For now uses dagster-cloud ci for other steps since those work out of the box and do not yet have dg equivalents. This should allow us to deploy to dagster+ without requiring a scaffolded dagster_cloud.yaml file.
