### PR TITLE
Fix stray ubuntu 20.04 references in dagster-cloud-action

### DIFF
--- a/github/serverless/branch_deployments.yml
+++ b/github/serverless/branch_deployments.yml
@@ -52,7 +52,7 @@ jobs:
 
   dagster_cloud_docker_deploy:
     name: Docker Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: needs.dagster_cloud_default_deploy.outputs.build_info
     needs: dagster_cloud_default_deploy
     strategy:

--- a/github/serverless/deploy.yml
+++ b/github/serverless/deploy.yml
@@ -54,7 +54,7 @@ jobs:
 
   dagster_cloud_docker_deploy:
     name: Docker Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: needs.dagster_cloud_default_deploy.outputs.build_info
     needs: dagster_cloud_default_deploy
     strategy:


### PR DESCRIPTION
Summary:
This runner is now defunct, upgrade to the same runner we reference elsewhere.
