### PR TITLE
Use dagster-dg-cli for dg GitHub action

### DIFF
--- a/actions/utils/dg-cli/action.yml
+++ b/actions/utils/dg-cli/action.yml
@@ -9,5 +9,5 @@ runs:
   using: "composite"
   steps:
     - id: dg-cli
-      run: $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_dg.cli.entrypoint ${{ inputs.command }}
+      run: $GITHUB_ACTION_PATH/../../../generated/gha/dagster-cloud.pex -m dagster_dg_cli.cli.entrypoint ${{ inputs.command }}
       shell: bash

--- a/actions/utils/dg-deploy-init/action.yaml
+++ b/actions/utils/dg-deploy-init/action.yaml
@@ -29,7 +29,7 @@ runs:
     # Initialize the deploy session
     - id: start-deploy-session
       run: >
-        $DAGSTER_CLOUD_PEX -m dagster_dg.cli.entrypoint plus deploy start
+        $DAGSTER_CLOUD_PEX -m dagster_dg_cli.cli.entrypoint plus deploy start
         --path=${{ inputs.project_dir }}
         --deployment=${{ inputs.deployment }}
         --status-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary

Updates the dg actions to point to the new `dagster-dg-cli` package instead of `dagster-dg`.