### PR TITLE
Add base_deployment_name to get branch deployment action

### DIFF
--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -62,6 +62,7 @@ runs:
       run: >
         cd $ACTION_REPO &&
         INPUT_DEPLOYMENT=${{ inputs.deployment }}
+        INPUT_BASE_DEPLOYMENT_NAME=${{ inputs.base_deployment_name }}
         /usr/bin/python src/deploy_pex.py
         ${{ inputs.dagster_cloud_file }}
         --python-version=${{ inputs.python_version }}

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: '3.8'
   deployment:
     required: false
-    description: "The deployment to push to, defaults to 'prod'. Ignored for pull requests where the branch deployment is used."
+    description: "The deployment to push to. For pull requests, this deployment will be used as the base deployment."
     default: "prod"
   deploy:
     description: 'Whether to upload the code files and update the code location'
@@ -62,7 +62,6 @@ runs:
       run: >
         cd $ACTION_REPO &&
         INPUT_DEPLOYMENT=${{ inputs.deployment }}
-        INPUT_BASE_DEPLOYMENT_NAME=${{ inputs.base_deployment_name }}
         /usr/bin/python src/deploy_pex.py
         ${{ inputs.dagster_cloud_file }}
         --python-version=${{ inputs.python_version }}

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -20,11 +20,14 @@ inputs:
     required: false
     description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
     default: 'true'
+  base_deployment_name:
+    required: false
+    description: "The name of the base deployment to use for the branch deployment."
 outputs:
   deployment:
     description: "Name of the branch deployment for this PR"
     value: ${{ steps.deploy.outputs.deployment }}
-    
+
 runs:
   using: "composite"
   steps:
@@ -112,6 +115,7 @@ runs:
         location: ${{ inputs.location }}
         image_tag: branch-${{ fromJson(inputs.location).name }}-${{ env.SHORT_SHA }}-${{ github.run_id }}-${{ github.run_attempt }}
         registry: ${{ env.REGISTRY_URL }}
+        base_deployment_name: ${{ inputs.base_deployment_name }}
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
 

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -11,6 +11,9 @@ inputs:
   deployment:
     required: false
     description: "The deployment to deploy to. If unset, automatically creates or updates the branch deployment associated with the branch."
+  base_deployment_name:
+    required: false
+    description: "The name of the base deployment to use for the branch deployment."
   pr:
     required: false
     description: "The PR identifier for this PR, if any, used for branch deployments."

--- a/actions/utils/get_branch_deployment/action.yml
+++ b/actions/utils/get_branch_deployment/action.yml
@@ -10,6 +10,9 @@ inputs:
   source_directory:
     required: false
     description: "Path to the source directory"
+  base_deployment_name:
+    required: false
+    description: "The name of the base deployment to use for the branch deployment."
 outputs:
   deployment:
     description: "The Cloud deployment associated with this branch."

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -88,7 +88,7 @@ if [ -z $INPUT_DEPLOYMENT ]; then
         --commit-message "$MESSAGE" \
         --author-name "$NAME" \
         --author-email "$EMAIL" \
-        "${EXTRA_PARAMS[@]}")
+        "${EXTRA_PARAMS[@]:-}")
 
 else
     export DEPLOYMENT_NAME=$INPUT_DEPLOYMENT

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -66,39 +66,30 @@ if [ -z $INPUT_DEPLOYMENT ]; then
     export EMAIL=$(git log -1 --format='%ae')
     export NAME=$(git log -1 --format='%an')
 
-    # Create or update branch deployment
-    if [ -z $AVATAR_URL ]; then
-        export DEPLOYMENT_NAME=$(dagster-cloud branch-deployment create-or-update \
-            --url "${DAGSTER_CLOUD_URL}" \
-            --api-token "$DAGSTER_CLOUD_API_TOKEN" \
-            --git-repo-name "$GIT_REPO" \
-            --branch-name "$BRANCH_NAME" \
-            --branch-url "$BRANCH_URL" \
-            --pull-request-url "$PR_URL" \
-            --pull-request-id "$PR_ID" \
-            --pull-request-status "$PR_STATUS" \
-            --commit-hash "$COMMIT_HASH" \
-            --timestamp "$TIMESTAMP" \
-            --commit-message "$MESSAGE" \
-            --author-name "$NAME" \
-            --author-email "$EMAIL")
-    else
-        export DEPLOYMENT_NAME=$(dagster-cloud branch-deployment create-or-update \
-            --url "${DAGSTER_CLOUD_URL}" \
-            --api-token "$DAGSTER_CLOUD_API_TOKEN" \
-            --git-repo-name "$GIT_REPO" \
-            --branch-name "$BRANCH_NAME" \
-            --branch-url "$BRANCH_URL" \
-            --pull-request-url "$PR_URL" \
-            --pull-request-id "$PR_ID" \
-            --pull-request-status "$PR_STATUS" \
-            --commit-hash "$COMMIT_HASH" \
-            --timestamp "$TIMESTAMP" \
-            --commit-message "$MESSAGE" \
-            --author-name "$NAME" \
-            --author-email "$EMAIL" \
-            --author-avatar-url "$AVATAR_URL")
+    EXTRA_PARAMS=()
+    if [[ $INPUT_BASE_DEPLOYMENT_NAME ]]; then
+        EXTRA_PARAMS+=(--base-deployment-name $INPUT_BASE_DEPLOYMENT_NAME)
     fi
+    if [[ $AVATAR_URL ]]; then
+        EXTRA_PARAMS+=(--author-avatar-url $AVATAR_URL)
+    fi
+
+    export DEPLOYMENT_NAME=$(dagster-cloud branch-deployment create-or-update \
+        --url "${DAGSTER_CLOUD_URL}" \
+        --api-token "$DAGSTER_CLOUD_API_TOKEN" \
+        --git-repo-name "$GIT_REPO" \
+        --branch-name "$BRANCH_NAME" \
+        --branch-url "$BRANCH_URL" \
+        --pull-request-url "$PR_URL" \
+        --pull-request-id "$PR_ID" \
+        --pull-request-status "$PR_STATUS" \
+        --commit-hash "$COMMIT_HASH" \
+        --timestamp "$TIMESTAMP" \
+        --commit-message "$MESSAGE" \
+        --author-name "$NAME" \
+        --author-email "$EMAIL" \
+        "${EXTRA_PARAMS[@]}")
+
 else
     export DEPLOYMENT_NAME=$INPUT_DEPLOYMENT
 fi

--- a/src/deploy_pex.py
+++ b/src/deploy_pex.py
@@ -30,7 +30,7 @@ def main():
         dagster_cloud_yaml = args[0]
         project_dir = os.path.dirname(dagster_cloud_yaml)
         deployment_name = get_branch_deployment_name(
-            project_dir, os.getenv("INPUT_BASE_DEPLOYMENT_NAME")
+            project_dir, base_deployment_name=os.getenv("INPUT_DEPLOYMENT", "prod")
         )
     else:
         # INPUT_DEPLOYMENT is to the `deployment:` input value in action.yml

--- a/src/get_branch_deployment.sh
+++ b/src/get_branch_deployment.sh
@@ -18,7 +18,6 @@ EXTRA_PARAMS=()
 if [ -n $INPUT_BASE_DEPLOYMENT_NAME ]; then
     EXTRA_PARAMS+=(--base-deployment-name $INPUT_BASE_DEPLOYMENT_NAME)
 fi
-echo "Using base deployment name: $INPUT_BASE_DEPLOYMENT_NAME"
 BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY "${EXTRA_PARAMS[@]:-}")
 
 echo "deployment=${BRANCH_DEPLOYMENT_NAME}" >> $GITHUB_OUTPUT

--- a/src/get_branch_deployment.sh
+++ b/src/get_branch_deployment.sh
@@ -14,6 +14,10 @@ fi
 
 git config --global --add safe.directory $(realpath $INPUT_SOURCE_DIRECTORY)
 
-BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY)
+if [ -z $INPUT_BASE_DEPLOYMENT_NAME ]; then
+    BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY)
+else
+    BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY --base-deployment-name $INPUT_BASE_DEPLOYMENT_NAME)
+fi
 
 echo "deployment=${BRANCH_DEPLOYMENT_NAME}" >> $GITHUB_OUTPUT

--- a/src/get_branch_deployment.sh
+++ b/src/get_branch_deployment.sh
@@ -14,10 +14,11 @@ fi
 
 git config --global --add safe.directory $(realpath $INPUT_SOURCE_DIRECTORY)
 
-if [ -z $INPUT_BASE_DEPLOYMENT_NAME ]; then
-    BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY)
-else
-    BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY --base-deployment-name $INPUT_BASE_DEPLOYMENT_NAME)
+EXTRA_PARAMS=()
+if [ -n $INPUT_BASE_DEPLOYMENT_NAME ]; then
+    EXTRA_PARAMS+=(--base-deployment-name $INPUT_BASE_DEPLOYMENT_NAME)
 fi
+echo "Using base deployment name: $INPUT_BASE_DEPLOYMENT_NAME"
+BRANCH_DEPLOYMENT_NAME=$(dagster-cloud ci branch-deployment $INPUT_SOURCE_DIRECTORY "${EXTRA_PARAMS[@]:-}")
 
 echo "deployment=${BRANCH_DEPLOYMENT_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Adds the option to configure a `base_deployment_name` for the serverless, hybrid deploy actions and the get branch deployment action.

## Test Plan

Tested against prod with test org.