### PR TITLE
add a --wait flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wheels/*whl
 
 # PyCharm IDE Config files
 .idea/
+.env

--- a/actions/launch_job/action.yml
+++ b/actions/launch_job/action.yml
@@ -23,6 +23,10 @@ inputs:
   job_name:
     required: true
     description: "The name of the job to launch."
+  wait:
+    required: false
+    default: "false"
+    description: "Whether to wait for the job to complete before exiting. When true, the action will wait for the run to finish and fail if the run fails."
 runs:
   using: "composite"
   steps:
@@ -53,5 +57,6 @@ runs:
         location_name: ${{ inputs.location_name }}
         repository_name: ${{ inputs.repository_name }}
         job_name: ${{ inputs.job_name }}
+        wait: ${{ inputs.wait }}
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}

--- a/actions/launch_job/action.yml
+++ b/actions/launch_job/action.yml
@@ -27,6 +27,9 @@ inputs:
     required: false
     default: "false"
     description: "Whether to wait for the job to complete before exiting. When true, the action will wait for the run to finish and fail if the run fails."
+  interval:
+    required: false
+    description: "Interval in seconds between status checks when waiting for job completion. Can only be used when wait is true."
 runs:
   using: "composite"
   steps:
@@ -58,5 +61,6 @@ runs:
         repository_name: ${{ inputs.repository_name }}
         job_name: ${{ inputs.job_name }}
         wait: ${{ inputs.wait }}
+        interval: ${{ inputs.interval }}
       env:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}

--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/copy_template/action.yml
+++ b/actions/utils/copy_template/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "A string of the base image name for the deployed code location image."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
   entrypoint: "/copy_template.sh"

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/deploy/action.yml
+++ b/actions/utils/deploy/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
   entrypoint: "/deploy.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/get_branch_deployment/action.yml
+++ b/actions/utils/get_branch_deployment/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
   entrypoint: "/get_branch_deployment.sh"

--- a/actions/utils/get_branch_deployment/action.yml
+++ b/actions/utils/get_branch_deployment/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: "The Cloud deployment associated with this branch."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
   entrypoint: "/get_branch_deployment.sh"

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/notify/action.yml
+++ b/actions/utils/notify/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
   entrypoint: "/notify.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/registry_info/action.yml
+++ b/actions/utils/registry_info/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
   entrypoint: "/registry_info.sh"

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -27,6 +27,10 @@ inputs:
     required: false
     description: "A JSON dict of config to apply to the run, input as a string."
     default: "{}"
+  wait:
+    required: false
+    default: "false"
+    description: "Whether to wait for the job to complete before exiting. When true, the action will wait for the run to finish and fail if the run fails."
   dagster_cloud_url:
     required: false
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -39,7 +39,5 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "../../../src/Dockerfile"
   entrypoint: "/run.sh"
-  args:
-    - ${{ inputs.pr }}

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -31,6 +31,9 @@ inputs:
     required: false
     default: "false"
     description: "Whether to wait for the job to complete before exiting. When true, the action will wait for the run to finish and fail if the run fails."
+  interval:
+    required: false
+    description: "Interval in seconds between status checks when waiting for job completion. Can only be used when wait is true."
   dagster_cloud_url:
     required: false
     description: "Alternative to providing organization ID. The URL of your Dagster Cloud organization."

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -39,5 +39,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "../../../src/Dockerfile"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
   entrypoint: "/run.sh"
+  args:
+    - ${{ inputs.pr }}

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/actions/utils/run/action.yml
+++ b/actions/utils/run/action.yml
@@ -42,7 +42,7 @@ outputs:
     description: "The ID of the launched run."
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:dev"
+  image: "docker://ghcr.io/dagster-io/dagster-cloud-action:add-wait-param"
   entrypoint: "/run.sh"
   args:
     - ${{ inputs.pr }}

--- a/gitlab/dbt/serverless-ci-dbt.yml
+++ b/gitlab/dbt/serverless-ci-dbt.yml
@@ -12,7 +12,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -51,7 +51,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   when: manual
   only:
     - merge_requests
@@ -76,7 +76,7 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     # install dbt package
     - pip install pip --upgrade

--- a/gitlab/dbt/serverless-ci-dbt.yml
+++ b/gitlab/dbt/serverless-ci-dbt.yml
@@ -12,7 +12,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -51,7 +51,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   when: manual
   only:
     - merge_requests
@@ -76,7 +76,7 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     # install dbt package
     - pip install pip --upgrade

--- a/gitlab/hybrid-ci.yml
+++ b/gitlab/hybrid-ci.yml
@@ -29,7 +29,7 @@ workflow:
 
 initialize:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     - export
     - dagster-cloud ci check --project-dir=$DAGSTER_PROJECT_DIR --dagster-cloud-yaml-path=$DAGSTER_CLOUD_YAML_PATH
@@ -75,7 +75,7 @@ deploy-docker:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -87,7 +87,7 @@ deploy-docker-branch:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -97,7 +97,7 @@ deploy-docker-branch:
 
 close-branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   when: manual
   only:
     - merge_requests

--- a/gitlab/hybrid-ci.yml
+++ b/gitlab/hybrid-ci.yml
@@ -29,7 +29,7 @@ workflow:
 
 initialize:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     - export
     - dagster-cloud ci check --project-dir=$DAGSTER_PROJECT_DIR --dagster-cloud-yaml-path=$DAGSTER_CLOUD_YAML_PATH
@@ -75,7 +75,7 @@ deploy-docker:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -87,7 +87,7 @@ deploy-docker-branch:
   dependencies:
     - build-image
     - initialize
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     - dagster-cloud ci set-build-output --image-tag=$IMAGE_TAG
     - dagster-cloud ci deploy
@@ -97,7 +97,7 @@ deploy-docker-branch:
 
 close-branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   when: manual
   only:
     - merge_requests

--- a/gitlab/serverless-ci.yml
+++ b/gitlab/serverless-ci.yml
@@ -9,7 +9,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -37,7 +37,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   when: manual
   only:
     - merge_requests
@@ -62,6 +62,6 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     - /gitlab_action/deploy.py ./dagster_cloud.yaml

--- a/gitlab/serverless-ci.yml
+++ b/gitlab/serverless-ci.yml
@@ -9,7 +9,7 @@ deploy-branch:
   stage: deploy
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     # first create the branch deployment
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
@@ -37,7 +37,7 @@ deploy-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   when: manual
   only:
     - merge_requests
@@ -62,6 +62,6 @@ deploy:
   stage: deploy
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     - /gitlab_action/deploy.py ./dagster_cloud.yaml

--- a/gitlab/serverless-legacy-ci.yml
+++ b/gitlab/serverless-legacy-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     - python /gitlab_action/parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -23,7 +23,7 @@ parse-workspace:
 
 fetch-registry-info:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script: dagster-cloud serverless registry-info --url $DAGSTER_CLOUD_URL/prod --api-token $DAGSTER_CLOUD_API_TOKEN | grep '=' >> registry.env
   artifacts:
     reports:
@@ -53,7 +53,7 @@ deploy-docker:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL/prod
@@ -74,7 +74,7 @@ deploy-docker-branch:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -109,7 +109,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
+  image: ghcr.io/dagster-io/dagster-cloud-action:dev
   when: manual
   only:
     - merge_requests

--- a/gitlab/serverless-legacy-ci.yml
+++ b/gitlab/serverless-legacy-ci.yml
@@ -10,7 +10,7 @@ workflow:
 
 parse-workspace:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     - python /gitlab_action/parse_workspace.py dagster_cloud.yaml >> build.env
     - cp /Dockerfile.template .
@@ -23,7 +23,7 @@ parse-workspace:
 
 fetch-registry-info:
   stage: setup
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script: dagster-cloud serverless registry-info --url $DAGSTER_CLOUD_URL/prod --api-token $DAGSTER_CLOUD_API_TOKEN | grep '=' >> registry.env
   artifacts:
     reports:
@@ -53,7 +53,7 @@ deploy-docker:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     - dagster-cloud workspace add-location
       --url $DAGSTER_CLOUD_URL/prod
@@ -74,7 +74,7 @@ deploy-docker-branch:
     - build-image
     - parse-workspace
     - fetch-registry-info
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   script:
     - export PR_TIMESTAMP=$(git log -1 --format='%cd' --date=unix)
     - export PR_MESSAGE=$(git log -1 --format='%s')
@@ -109,7 +109,7 @@ deploy-docker-branch:
 
 close_branch:
   stage: deploy
-  image: ghcr.io/dagster-io/dagster-cloud-action:dev
+  image: ghcr.io/dagster-io/dagster-cloud-action:add-wait-param
   when: manual
   only:
     - merge_requests

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -229,7 +229,7 @@ def create_rc(
     branch = ensure_in_branch()
     info(f"Preparing a new RC in {branch}")
 
-    if version_tag != "add-wait-param" and not re.match(r"^[0-9.]+$", version_tag):
+    if version_tag != "dev" and not re.match(r"^[0-9.]+$", version_tag):
         error(f"Invalid version tag {version_tag}")
         sys.exit(1)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -78,6 +78,7 @@ def build_docker_action(version_tag: str, publish_docker_action: bool = True):
                 [
                     "docker",
                     "push",
+                    "--platform=linux/amd64",
                     image_name,
                 ],
                 encoding="utf-8",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -202,7 +202,7 @@ def update_docker_action_references(
     glob_patterns: List[str] = ["**/*yaml", "**/*yml"],
 ):
     image_name = get_docker_action_image_name(version_tag)
-    previous_image_name = get_docker_action_image_name("dev")
+    previous_image_name = get_docker_action_image_name("add-wait-param")
     info(f"Updating references from {previous_image_name} to {image_name}")
     with chdir("."):
         for pattern in glob_patterns:
@@ -229,7 +229,7 @@ def create_rc(
     branch = ensure_in_branch()
     info(f"Preparing a new RC in {branch}")
 
-    if version_tag != "dev" and not re.match(r"^[0-9.]+$", version_tag):
+    if version_tag != "add-wait-param" and not re.match(r"^[0-9.]+$", version_tag):
         error(f"Invalid version tag {version_tag}")
         sys.exit(1)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -228,7 +228,7 @@ def create_rc(
     branch = ensure_in_branch()
     info(f"Preparing a new RC in {branch}")
 
-    if version_tag != "dev" and not re.match(r"^[0-9.]+$", version_tag):
+    if version_tag != "add-wait-param" and not re.match(r"^[0-9.]+$", version_tag):
         error(f"Invalid version tag {version_tag}")
         sys.exit(1)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -66,6 +66,7 @@ def build_docker_action(version_tag: str, publish_docker_action: bool = True):
                 ".",
                 "-f",
                 "src/Dockerfile",
+                "--platform=linux/amd64",
                 "-t",
                 image_name,
             ],
@@ -78,7 +79,6 @@ def build_docker_action(version_tag: str, publish_docker_action: bool = True):
                 [
                     "docker",
                     "push",
-                    "--platform=linux/amd64",
                     image_name,
                 ],
                 encoding="utf-8",

--- a/src/run.sh
+++ b/src/run.sh
@@ -29,30 +29,39 @@ case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-# Run the command and capture all output while streaming to console
+# Run the command with real-time streaming and proper blocking
 echo "Launching dagster-cloud job..."
+
+# Create a temporary file for output capture  
 TEMP_OUTPUT_FILE=$(mktemp)
 
-# Use tee to both display output and capture it
-dagster-cloud job launch \
-    --url "${DAGSTER_CLOUD_URL}" \
-    --deployment "${INPUT_DEPLOYMENT}" \
-    --api-token "$DAGSTER_CLOUD_API_TOKEN" \
-    --location "${INPUT_LOCATION_NAME}" \
-    --repository "${INPUT_REPOSITORY_NAME}" \
-    --job "${INPUT_JOB_NAME}" \
-    --tags "${INPUT_TAGS_JSON}" \
-    --config-json "${INPUT_CONFIG_JSON}" \
-    ${wait_flag} ${interval_flag} 2>&1 | tee "${TEMP_OUTPUT_FILE}"
-
-# Check the exit code of the dagster-cloud command (not tee)
-DAGSTER_EXIT_CODE=${PIPESTATUS[0]}
+# Use a simple approach: run command while capturing output
+# The key insight: avoid pipes, use file redirection + background monitoring
+(
+    # Run the actual command, redirecting to temp file
+    dagster-cloud job launch \
+        --url "${DAGSTER_CLOUD_URL}" \
+        --deployment "${INPUT_DEPLOYMENT}" \
+        --api-token "$DAGSTER_CLOUD_API_TOKEN" \
+        --location "${INPUT_LOCATION_NAME}" \
+        --repository "${INPUT_REPOSITORY_NAME}" \
+        --job "${INPUT_JOB_NAME}" \
+        --tags "${INPUT_TAGS_JSON}" \
+        --config-json "${INPUT_CONFIG_JSON}" \
+        ${wait_flag} ${interval_flag} 2>&1 | while IFS= read -r line; do
+            echo "$line"  # Stream to console
+            echo "$line" >> "$TEMP_OUTPUT_FILE"  # Capture to file
+        done
+    # Pass through the exit code
+    exit ${PIPESTATUS[0]}
+)
+DAGSTER_EXIT_CODE=$?
 
 # Read the captured output for run ID extraction
-COMMAND_OUTPUT=$(cat "${TEMP_OUTPUT_FILE}")
+COMMAND_OUTPUT=$(cat "$TEMP_OUTPUT_FILE")
 
-# Clean up temp file
-rm -f "${TEMP_OUTPUT_FILE}"
+# Clean up temporary files
+rm -f "$TEMP_OUTPUT_FILE"
 
 # Check if the command failed
 if [ $DAGSTER_EXIT_CODE -ne 0 ]; then

--- a/src/run.sh
+++ b/src/run.sh
@@ -29,14 +29,8 @@ case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-# Run the command - prioritize blocking behavior over real-time streaming
+# Run the command - simple blocking approach
 echo "Launching dagster-cloud job..."
-
-# Debug: Show the exact command being run
-echo "Command flags: wait_flag='${wait_flag}' interval_flag='${interval_flag}'"
-
-# Simple approach: run the command directly and let it block naturally
-# The --wait flag will cause this command to block until job completion
 
 # Build the command args array to handle empty flags properly
 cmd_args=(
@@ -61,22 +55,12 @@ if [ -n "${interval_flag}" ]; then
     cmd_args+=(${interval_flag})  # This will split --interval and the value
 fi
 
-echo "Running command: ${cmd_args[*]}"
-
-# Create a temporary file to capture output for run ID extraction
-TEMP_OUTPUT_FILE=$(mktemp)
-
-# Run command with real-time output and proper exit code handling
-exec 5> >(tee "$TEMP_OUTPUT_FILE")
-"${cmd_args[@]}" >&5 2>&5
+# Run the command directly - this will naturally block if --wait is used
+COMMAND_OUTPUT=$("${cmd_args[@]}" 2>&1)
 DAGSTER_EXIT_CODE=$?
-exec 5>&-
 
-# Read the captured output for run ID extraction  
-COMMAND_OUTPUT=$(cat "$TEMP_OUTPUT_FILE")
-
-# Clean up
-rm -f "$TEMP_OUTPUT_FILE"
+# Display the output after command completion
+echo "$COMMAND_OUTPUT"
 
 # Check if the command failed
 if [ $DAGSTER_EXIT_CODE -ne 0 ]; then

--- a/src/run.sh
+++ b/src/run.sh
@@ -27,18 +27,6 @@ esac
 
 echo "DEBUG: wait_flag result: '${wait_flag}'"
 
-# Check dagster-cloud CLI version and available flags
-echo "DEBUG: dagster-cloud version:"
-dagster-cloud --version || echo "Failed to get version"
-
-echo "DEBUG: dagster-cloud job launch help:"
-dagster-cloud job launch --help | grep -A 5 -B 5 wait || echo "No wait flag found in help"
-
-# Build the command for debugging
-DAGSTER_CMD="dagster-cloud job launch --url \"${DAGSTER_CLOUD_URL}\" --deployment \"${INPUT_DEPLOYMENT}\" --api-token \"$DAGSTER_CLOUD_API_TOKEN\" --location \"${INPUT_LOCATION_NAME}\" --repository \"${INPUT_REPOSITORY_NAME}\" --job \"${INPUT_JOB_NAME}\" --tags \"${INPUT_TAGS_JSON}\" --config-json \"${INPUT_CONFIG_JSON}\" ${wait_flag}"
-
-echo "DEBUG: About to run command: ${DAGSTER_CMD}"
-
 RUN_ID=$(
     dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}" \

--- a/src/run.sh
+++ b/src/run.sh
@@ -29,9 +29,12 @@ case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-# Run the command and capture all output
-COMMAND_OUTPUT=$(
-    dagster-cloud job launch \
+# Run the command and capture all output while streaming to console
+echo "Launching dagster-cloud job..."
+TEMP_OUTPUT_FILE=$(mktemp)
+
+# Use tee to both display output and capture it
+dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}" \
     --deployment "${INPUT_DEPLOYMENT}" \
     --api-token "$DAGSTER_CLOUD_API_TOKEN" \
@@ -40,8 +43,22 @@ COMMAND_OUTPUT=$(
     --job "${INPUT_JOB_NAME}" \
     --tags "${INPUT_TAGS_JSON}" \
     --config-json "${INPUT_CONFIG_JSON}" \
-    ${wait_flag} ${interval_flag} 2>&1
-)
+    ${wait_flag} ${interval_flag} 2>&1 | tee "${TEMP_OUTPUT_FILE}"
+
+# Check the exit code of the dagster-cloud command (not tee)
+DAGSTER_EXIT_CODE=${PIPESTATUS[0]}
+
+# Read the captured output for run ID extraction
+COMMAND_OUTPUT=$(cat "${TEMP_OUTPUT_FILE}")
+
+# Clean up temp file
+rm -f "${TEMP_OUTPUT_FILE}"
+
+# Check if the command failed
+if [ $DAGSTER_EXIT_CODE -ne 0 ]; then
+    echo "ERROR: dagster-cloud job launch failed with exit code $DAGSTER_EXIT_CODE"
+    exit $DAGSTER_EXIT_CODE
+fi
 
 # Extract run ID from the output
 # Look for patterns like "Run <run-id> is in progress" or "Run <run-id> finished"

--- a/src/run.sh
+++ b/src/run.sh
@@ -29,7 +29,6 @@ case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-# Run the command - simple blocking approach
 echo "Launching dagster-cloud job..."
 
 # Build the command args array to handle empty flags properly

--- a/src/run.sh
+++ b/src/run.sh
@@ -46,13 +46,13 @@ echo "$COMMAND_OUTPUT"
 # Extract run ID from the output
 # Look for patterns like "Run <run-id> is in progress" or "Run <run-id> finished"
 RUN_ID=""
-if [[ "$COMMAND_OUTPUT" =~ Run\ ([a-f0-9-]{36}) ]]; then
+if [[ "$COMMAND_OUTPUT" =~ Run\ ([a-f0-9-]+) ]]; then
     RUN_ID="${BASH_REMATCH[1]}"
     echo "DEBUG: Extracted run ID from status output: ${RUN_ID}"
 else
     # Try to get the first line if it looks like a run ID (for non-wait mode)
     FIRST_LINE=$(echo "$COMMAND_OUTPUT" | head -n1 | tr -d '\n\r')
-    if [[ "$FIRST_LINE" =~ ^[a-f0-9-]{36}$ ]]; then
+    if [[ "$FIRST_LINE" =~ ^[a-zA-Z0-9-]+$ ]]; then
         RUN_ID="$FIRST_LINE"
         echo "DEBUG: Using first line as run ID: ${RUN_ID}"
     else

--- a/src/run.sh
+++ b/src/run.sh
@@ -66,13 +66,11 @@ echo "Running command: ${cmd_args[*]}"
 # Create a temporary file to capture output for run ID extraction
 TEMP_OUTPUT_FILE=$(mktemp)
 
-# Simplest approach that definitely works: run with tee for dual output
-# This preserves the blocking behavior while providing real-time output
-"${cmd_args[@]}" 2>&1 | tee "$TEMP_OUTPUT_FILE"
-
-# The tee command will complete when the dagster-cloud command completes
-# So we get the exit status of the dagster-cloud command
-DAGSTER_EXIT_CODE=${PIPESTATUS[0]}
+# Run command with real-time output and proper exit code handling
+exec 5> >(tee "$TEMP_OUTPUT_FILE")
+"${cmd_args[@]}" >&5 2>&5
+DAGSTER_EXIT_CODE=$?
+exec 5>&-
 
 # Read the captured output for run ID extraction  
 COMMAND_OUTPUT=$(cat "$TEMP_OUTPUT_FILE")

--- a/src/run.sh
+++ b/src/run.sh
@@ -9,24 +9,6 @@ if [ -z $DAGSTER_CLOUD_URL ]; then
     fi
 fi
 
-# Debug: Print the wait parameter value for troubleshooting
-echo "DEBUG: INPUT_WAIT value: '${INPUT_WAIT}'"
-echo "DEBUG: INPUT_WAIT lowercase: '$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')'"
-
-# Check for wait flag - handle various true values
-wait_flag=""
-case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
-    "true"|"1"|"yes"|"on")
-        wait_flag="--wait"
-        echo "DEBUG: Wait flag enabled"
-        ;;
-    *)
-        echo "DEBUG: Wait flag disabled"
-        ;;
-esac
-
-echo "DEBUG: wait_flag result: '${wait_flag}'"
-
 RUN_ID=$(
     dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}" \
@@ -37,7 +19,7 @@ RUN_ID=$(
     --job "${INPUT_JOB_NAME}" \
     --tags "${INPUT_TAGS_JSON}" \
     --config-json "${INPUT_CONFIG_JSON}" \
-    ${wait_flag}
+    $(if [ "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then echo "--wait"; fi)
 )
 
 if [ -z $RUN_ID ]; then

--- a/src/run.sh
+++ b/src/run.sh
@@ -9,22 +9,13 @@ if [ -z $DAGSTER_CLOUD_URL ]; then
     fi
 fi
 
-# Debug: Print the wait parameter value for troubleshooting
-echo "DEBUG: INPUT_WAIT value: '${INPUT_WAIT}'"
-
 # Check for wait flag - handle various true values
 wait_flag=""
 case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
     "true"|"1"|"yes"|"on")
         wait_flag="--wait"
-        echo "DEBUG: Wait flag enabled"
-        ;;
-    *)
-        echo "DEBUG: Wait flag disabled"
         ;;
 esac
-
-echo "DEBUG: About to run command with wait_flag: '${wait_flag}'"
 
 # Run the command and capture all output
 COMMAND_OUTPUT=$(
@@ -40,23 +31,16 @@ COMMAND_OUTPUT=$(
     ${wait_flag} 2>&1
 )
 
-echo "DEBUG: Command output:"
-echo "$COMMAND_OUTPUT"
-
 # Extract run ID from the output
 # Look for patterns like "Run <run-id> is in progress" or "Run <run-id> finished"
 RUN_ID=""
 if [[ "$COMMAND_OUTPUT" =~ Run\ ([a-f0-9-]+) ]]; then
     RUN_ID="${BASH_REMATCH[1]}"
-    echo "DEBUG: Extracted run ID from status output: ${RUN_ID}"
 else
     # Try to get the first line if it looks like a run ID (for non-wait mode)
     FIRST_LINE=$(echo "$COMMAND_OUTPUT" | head -n1 | tr -d '\n\r')
     if [[ "$FIRST_LINE" =~ ^[a-zA-Z0-9-]+$ ]]; then
         RUN_ID="$FIRST_LINE"
-        echo "DEBUG: Using first line as run ID: ${RUN_ID}"
-    else
-        echo "DEBUG: Could not extract run ID from output"
     fi
 fi
 

--- a/src/run.sh
+++ b/src/run.sh
@@ -11,9 +11,21 @@ fi
 
 # Check for wait flag - handle various true values
 wait_flag=""
+interval_flag=""
 case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
     "true"|"1"|"yes"|"on")
         wait_flag="--wait"
+        # Only add interval flag if wait is enabled and interval is provided
+        if [ -n "${INPUT_INTERVAL}" ]; then
+            interval_flag="--interval ${INPUT_INTERVAL}"
+        fi
+        ;;
+    *)
+        # Validate that interval is not used without wait
+        if [ -n "${INPUT_INTERVAL}" ]; then
+            echo "ERROR: interval parameter can only be used when wait is true"
+            exit 1
+        fi
         ;;
 esac
 
@@ -28,7 +40,7 @@ COMMAND_OUTPUT=$(
     --job "${INPUT_JOB_NAME}" \
     --tags "${INPUT_TAGS_JSON}" \
     --config-json "${INPUT_CONFIG_JSON}" \
-    ${wait_flag} 2>&1
+    ${wait_flag} ${interval_flag} 2>&1
 )
 
 # Extract run ID from the output

--- a/src/run.sh
+++ b/src/run.sh
@@ -44,21 +44,18 @@ echo "DEBUG: Command output:"
 echo "$COMMAND_OUTPUT"
 
 # Extract run ID from the output
-# The run ID should be in format like "Run <run-id> is in progress" or just "<run-id>"
-if [[ "$COMMAND_OUTPUT" =~ Run\ ([a-f0-9-]+) ]]; then
+# Look for patterns like "Run <run-id> is in progress" or "Run <run-id> finished"
+RUN_ID=""
+if [[ "$COMMAND_OUTPUT" =~ Run\ ([a-f0-9-]{36}) ]]; then
     RUN_ID="${BASH_REMATCH[1]}"
     echo "DEBUG: Extracted run ID from status output: ${RUN_ID}"
-elif [[ "$COMMAND_OUTPUT" =~ ^[a-f0-9-]+$ ]]; then
-    RUN_ID="$COMMAND_OUTPUT"
-    echo "DEBUG: Using direct run ID output: ${RUN_ID}"
 else
-    # Try to get the first line if it looks like a run ID
+    # Try to get the first line if it looks like a run ID (for non-wait mode)
     FIRST_LINE=$(echo "$COMMAND_OUTPUT" | head -n1 | tr -d '\n\r')
-    if [[ "$FIRST_LINE" =~ ^[a-f0-9-]+$ ]]; then
+    if [[ "$FIRST_LINE" =~ ^[a-f0-9-]{36}$ ]]; then
         RUN_ID="$FIRST_LINE"
         echo "DEBUG: Using first line as run ID: ${RUN_ID}"
     else
-        RUN_ID=""
         echo "DEBUG: Could not extract run ID from output"
     fi
 fi

--- a/src/run.sh
+++ b/src/run.sh
@@ -9,7 +9,25 @@ if [ -z $DAGSTER_CLOUD_URL ]; then
     fi
 fi
 
-RUN_ID=$(
+# Debug: Print the wait parameter value for troubleshooting
+echo "DEBUG: INPUT_WAIT value: '${INPUT_WAIT}'"
+
+# Check for wait flag - handle various true values
+wait_flag=""
+case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
+    "true"|"1"|"yes"|"on")
+        wait_flag="--wait"
+        echo "DEBUG: Wait flag enabled"
+        ;;
+    *)
+        echo "DEBUG: Wait flag disabled"
+        ;;
+esac
+
+echo "DEBUG: About to run command with wait_flag: '${wait_flag}'"
+
+# Run the command and capture all output
+COMMAND_OUTPUT=$(
     dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}" \
     --deployment "${INPUT_DEPLOYMENT}" \
@@ -19,11 +37,35 @@ RUN_ID=$(
     --job "${INPUT_JOB_NAME}" \
     --tags "${INPUT_TAGS_JSON}" \
     --config-json "${INPUT_CONFIG_JSON}" \
-    $(if [ "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then echo "--wait"; fi)
+    ${wait_flag} 2>&1
 )
 
-if [ -z $RUN_ID ]; then
-    echo "Failed to launch run"
+echo "DEBUG: Command output:"
+echo "$COMMAND_OUTPUT"
+
+# Extract run ID from the output
+# The run ID should be in format like "Run <run-id> is in progress" or just "<run-id>"
+if [[ "$COMMAND_OUTPUT" =~ Run\ ([a-f0-9-]+) ]]; then
+    RUN_ID="${BASH_REMATCH[1]}"
+    echo "DEBUG: Extracted run ID from status output: ${RUN_ID}"
+elif [[ "$COMMAND_OUTPUT" =~ ^[a-f0-9-]+$ ]]; then
+    RUN_ID="$COMMAND_OUTPUT"
+    echo "DEBUG: Using direct run ID output: ${RUN_ID}"
+else
+    # Try to get the first line if it looks like a run ID
+    FIRST_LINE=$(echo "$COMMAND_OUTPUT" | head -n1 | tr -d '\n\r')
+    if [[ "$FIRST_LINE" =~ ^[a-f0-9-]+$ ]]; then
+        RUN_ID="$FIRST_LINE"
+        echo "DEBUG: Using first line as run ID: ${RUN_ID}"
+    else
+        RUN_ID=""
+        echo "DEBUG: Could not extract run ID from output"
+    fi
+fi
+
+if [ -z "$RUN_ID" ]; then
+    echo "Failed to launch run or extract run ID"
+    echo "Command output was: $COMMAND_OUTPUT"
     exit 1
 else
     echo "Successfully launched run: ${RUN_ID}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -9,6 +9,24 @@ if [ -z $DAGSTER_CLOUD_URL ]; then
     fi
 fi
 
+# Debug: Print the wait parameter value for troubleshooting
+echo "DEBUG: INPUT_WAIT value: '${INPUT_WAIT}'"
+echo "DEBUG: INPUT_WAIT lowercase: '$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')'"
+
+# Check for wait flag - handle various true values
+wait_flag=""
+case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
+    "true"|"1"|"yes"|"on")
+        wait_flag="--wait"
+        echo "DEBUG: Wait flag enabled"
+        ;;
+    *)
+        echo "DEBUG: Wait flag disabled"
+        ;;
+esac
+
+echo "DEBUG: wait_flag result: '${wait_flag}'"
+
 RUN_ID=$(
     dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}" \
@@ -19,7 +37,7 @@ RUN_ID=$(
     --job "${INPUT_JOB_NAME}" \
     --tags "${INPUT_TAGS_JSON}" \
     --config-json "${INPUT_CONFIG_JSON}" \
-    $(if [ "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then echo "--wait"; fi)
+    ${wait_flag}
 )
 
 if [ -z $RUN_ID ]; then

--- a/src/run.sh
+++ b/src/run.sh
@@ -27,6 +27,18 @@ esac
 
 echo "DEBUG: wait_flag result: '${wait_flag}'"
 
+# Check dagster-cloud CLI version and available flags
+echo "DEBUG: dagster-cloud version:"
+dagster-cloud --version || echo "Failed to get version"
+
+echo "DEBUG: dagster-cloud job launch help:"
+dagster-cloud job launch --help | grep -A 5 -B 5 wait || echo "No wait flag found in help"
+
+# Build the command for debugging
+DAGSTER_CMD="dagster-cloud job launch --url \"${DAGSTER_CLOUD_URL}\" --deployment \"${INPUT_DEPLOYMENT}\" --api-token \"$DAGSTER_CLOUD_API_TOKEN\" --location \"${INPUT_LOCATION_NAME}\" --repository \"${INPUT_REPOSITORY_NAME}\" --job \"${INPUT_JOB_NAME}\" --tags \"${INPUT_TAGS_JSON}\" --config-json \"${INPUT_CONFIG_JSON}\" ${wait_flag}"
+
+echo "DEBUG: About to run command: ${DAGSTER_CMD}"
+
 RUN_ID=$(
     dagster-cloud job launch \
     --url "${DAGSTER_CLOUD_URL}" \

--- a/src/run.sh
+++ b/src/run.sh
@@ -29,38 +29,55 @@ case "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-# Run the command with real-time streaming and proper blocking
+# Run the command - prioritize blocking behavior over real-time streaming
 echo "Launching dagster-cloud job..."
 
-# Create a temporary file for output capture  
+# Debug: Show the exact command being run
+echo "Command flags: wait_flag='${wait_flag}' interval_flag='${interval_flag}'"
+
+# Simple approach: run the command directly and let it block naturally
+# The --wait flag will cause this command to block until job completion
+
+# Build the command args array to handle empty flags properly
+cmd_args=(
+    "dagster-cloud" "job" "launch"
+    "--url" "${DAGSTER_CLOUD_URL}"
+    "--deployment" "${INPUT_DEPLOYMENT}"
+    "--api-token" "$DAGSTER_CLOUD_API_TOKEN"
+    "--location" "${INPUT_LOCATION_NAME}"
+    "--repository" "${INPUT_REPOSITORY_NAME}"
+    "--job" "${INPUT_JOB_NAME}"
+    "--tags" "${INPUT_TAGS_JSON}"
+    "--config-json" "${INPUT_CONFIG_JSON}"
+)
+
+# Add wait flag if set
+if [ -n "${wait_flag}" ]; then
+    cmd_args+=("${wait_flag}")
+fi
+
+# Add interval flag if set
+if [ -n "${interval_flag}" ]; then
+    cmd_args+=(${interval_flag})  # This will split --interval and the value
+fi
+
+echo "Running command: ${cmd_args[*]}"
+
+# Create a temporary file to capture output for run ID extraction
 TEMP_OUTPUT_FILE=$(mktemp)
 
-# Use a simple approach: run command while capturing output
-# The key insight: avoid pipes, use file redirection + background monitoring
-(
-    # Run the actual command, redirecting to temp file
-    dagster-cloud job launch \
-        --url "${DAGSTER_CLOUD_URL}" \
-        --deployment "${INPUT_DEPLOYMENT}" \
-        --api-token "$DAGSTER_CLOUD_API_TOKEN" \
-        --location "${INPUT_LOCATION_NAME}" \
-        --repository "${INPUT_REPOSITORY_NAME}" \
-        --job "${INPUT_JOB_NAME}" \
-        --tags "${INPUT_TAGS_JSON}" \
-        --config-json "${INPUT_CONFIG_JSON}" \
-        ${wait_flag} ${interval_flag} 2>&1 | while IFS= read -r line; do
-            echo "$line"  # Stream to console
-            echo "$line" >> "$TEMP_OUTPUT_FILE"  # Capture to file
-        done
-    # Pass through the exit code
-    exit ${PIPESTATUS[0]}
-)
-DAGSTER_EXIT_CODE=$?
+# Simplest approach that definitely works: run with tee for dual output
+# This preserves the blocking behavior while providing real-time output
+"${cmd_args[@]}" 2>&1 | tee "$TEMP_OUTPUT_FILE"
 
-# Read the captured output for run ID extraction
+# The tee command will complete when the dagster-cloud command completes
+# So we get the exit status of the dagster-cloud command
+DAGSTER_EXIT_CODE=${PIPESTATUS[0]}
+
+# Read the captured output for run ID extraction  
 COMMAND_OUTPUT=$(cat "$TEMP_OUTPUT_FILE")
 
-# Clean up temporary files
+# Clean up
 rm -f "$TEMP_OUTPUT_FILE"
 
 # Check if the command failed

--- a/src/run.sh
+++ b/src/run.sh
@@ -18,7 +18,8 @@ RUN_ID=$(
     --repository "${INPUT_REPOSITORY_NAME}" \
     --job "${INPUT_JOB_NAME}" \
     --tags "${INPUT_TAGS_JSON}" \
-    --config-json "${INPUT_CONFIG_JSON}"
+    --config-json "${INPUT_CONFIG_JSON}" \
+    $(if [ "$(echo "${INPUT_WAIT}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then echo "--wait"; fi)
 )
 
 if [ -z $RUN_ID ]; then

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,4 +1,185 @@
+def test_run_without_wait(tmp_path, exec_context, action_docker_image_id):
+    """Test the run script without wait flag (default behavior)."""
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
+
+    exec_context.set_env(
+        {
+            "GITHUB_ACTIONS": "true",
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "INPUT_LOCATION_NAME": "some-location",
+            "INPUT_REPOSITORY_NAME": "some-repository",
+            "INPUT_JOB_NAME": "some-job",
+            "INPUT_TAGS_JSON": "some-tags",
+            "INPUT_CONFIG_JSON": "some-config-json",
+            "INPUT_WAIT": "false",  # Explicitly set to false
+            "GITHUB_OUTPUT": output_file.name,
+        }
+    )
+
+    exec_context.stub_command(
+        "dagster-cloud",
+        {
+            "job launch --url http://dagster.cloud/test "
+            "--deployment prod "
+            "--api-token api-token "
+            "--location some-location "
+            "--repository some-repository "
+            "--job some-job "
+            "--tags some-tags "
+            "--config-json some-config-json": "ee1ecc27-1dbe-435d-bd62-c2b1c491eef6",
+        },
+    )
+    exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+    stdout = exec_context.get_stdout()
+    
+    assert "DEBUG: Wait flag disabled" in stdout
+    assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
+    assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
+
+
+def test_run_with_wait_true(tmp_path, exec_context, action_docker_image_id):
+    """Test the run script with wait flag enabled."""
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
+
+    exec_context.set_env(
+        {
+            "GITHUB_ACTIONS": "true",
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "INPUT_LOCATION_NAME": "some-location",
+            "INPUT_REPOSITORY_NAME": "some-repository",
+            "INPUT_JOB_NAME": "some-job",
+            "INPUT_TAGS_JSON": "some-tags",
+            "INPUT_CONFIG_JSON": "some-config-json",
+            "INPUT_WAIT": "true",
+            "GITHUB_OUTPUT": output_file.name,
+        }
+    )
+
+    # Mock the multi-line output that dagster-cloud CLI produces with --wait
+    multi_line_output = """Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 is in progress (status: STARTING)...
+Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 is in progress (status: STARTED)...
+Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 is in progress (status: STARTED)...
+Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
+
+    exec_context.stub_command(
+        "dagster-cloud",
+        {
+            "job launch --url http://dagster.cloud/test "
+            "--deployment prod "
+            "--api-token api-token "
+            "--location some-location "
+            "--repository some-repository "
+            "--job some-job "
+            "--tags some-tags "
+            "--config-json some-config-json "
+            "--wait": multi_line_output,
+        },
+    )
+    exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+    stdout = exec_context.get_stdout()
+    
+    assert "DEBUG: Wait flag enabled" in stdout
+    assert "DEBUG: Extracted run ID from status output: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
+    assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
+    assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
+
+
+def test_run_with_wait_various_values(tmp_path, exec_context, action_docker_image_id):
+    """Test that various truthy values for wait parameter work."""
+    for wait_value in ["True", "TRUE", "1", "yes", "Yes", "YES", "on"]:
+        output_file = tmp_path / "output.txt"
+        output_file.touch()
+        
+        # Reset exec_context for each iteration
+        exec_context.reset()
+        exec_context.set_env(
+            {
+                "GITHUB_ACTIONS": "true",
+                "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+                "INPUT_DEPLOYMENT": "prod",
+                "DAGSTER_CLOUD_API_TOKEN": "api-token",
+                "INPUT_LOCATION_NAME": "some-location",
+                "INPUT_REPOSITORY_NAME": "some-repository",
+                "INPUT_JOB_NAME": "some-job",
+                "INPUT_TAGS_JSON": "some-tags",
+                "INPUT_CONFIG_JSON": "some-config-json",
+                "INPUT_WAIT": wait_value,
+                "GITHUB_OUTPUT": output_file.name,
+            }
+        )
+
+        exec_context.stub_command(
+            "dagster-cloud",
+            {
+                "job launch --url http://dagster.cloud/test "
+                "--deployment prod "
+                "--api-token api-token "
+                "--location some-location "
+                "--repository some-repository "
+                "--job some-job "
+                "--tags some-tags "
+                "--config-json some-config-json "
+                "--wait": "Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully.",
+            },
+        )
+        exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+        stdout = exec_context.get_stdout()
+        
+        assert "DEBUG: Wait flag enabled" in stdout, f"Failed for wait_value: {wait_value}"
+        break  # Only test one value since exec_context can only run once
+
+
+def test_run_legacy_compatibility(tmp_path, exec_context, action_docker_image_id):
+    """Test backwards compatibility when INPUT_WAIT is not set."""
+    output_file = tmp_path / "output.txt" 
+    output_file.touch()
+
+    exec_context.set_env(
+        {
+            "GITHUB_ACTIONS": "true",
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "INPUT_LOCATION_NAME": "some-location",
+            "INPUT_REPOSITORY_NAME": "some-repository",
+            "INPUT_JOB_NAME": "some-job",
+            "INPUT_TAGS_JSON": "some-tags",
+            "INPUT_CONFIG_JSON": "some-config-json",
+            # Note: No INPUT_WAIT set
+            "GITHUB_OUTPUT": output_file.name,
+        }
+    )
+
+    exec_context.stub_command(
+        "dagster-cloud",
+        {
+            "job launch --url http://dagster.cloud/test "
+            "--deployment prod "
+            "--api-token api-token "
+            "--location some-location "
+            "--repository some-repository "
+            "--job some-job "
+            "--tags some-tags "
+            "--config-json some-config-json": "ee1ecc27-1dbe-435d-bd62-c2b1c491eef6",
+        },
+    )
+    exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+    stdout = exec_context.get_stdout()
+    
+    assert "DEBUG: Wait flag disabled" in stdout
+    assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
+    assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
+
+
+# Keep the original test for backwards compatibility
 def test_run(tmp_path, exec_context, action_docker_image_id):
+    """Original test maintained for backwards compatibility."""
     output_file = tmp_path / "output.txt"
     output_file.touch()
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -170,6 +170,135 @@ def test_run_legacy_compatibility(tmp_path, exec_context, action_docker_image_id
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
 
+def test_run_with_wait_and_interval(tmp_path, exec_context, action_docker_image_id):
+    """Test the run script with wait and interval flags enabled."""
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
+
+    exec_context.set_env(
+        {
+            "GITHUB_ACTIONS": "true",
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "INPUT_LOCATION_NAME": "some-location",
+            "INPUT_REPOSITORY_NAME": "some-repository",
+            "INPUT_JOB_NAME": "some-job",
+            "INPUT_TAGS_JSON": "some-tags",
+            "INPUT_CONFIG_JSON": "some-config-json",
+            "INPUT_WAIT": "true",
+            "INPUT_INTERVAL": "10",
+            "GITHUB_OUTPUT": output_file.name,
+        }
+    )
+
+    # Mock the multi-line output that dagster-cloud CLI produces with --wait --interval
+    multi_line_output = """Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 is in progress (status: STARTING)...
+Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 is in progress (status: STARTED)...
+Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
+
+    exec_context.stub_command(
+        "dagster-cloud",
+        {
+            "job launch --url http://dagster.cloud/test "
+            "--deployment prod "
+            "--api-token api-token "
+            "--location some-location "
+            "--repository some-repository "
+            "--job some-job "
+            "--tags some-tags "
+            "--config-json some-config-json "
+            "--wait "
+            "--interval 10": multi_line_output,
+        },
+    )
+    exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+    stdout = exec_context.get_stdout()
+    
+    assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
+    assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
+
+
+def test_run_with_wait_no_interval(tmp_path, exec_context, action_docker_image_id):
+    """Test the run script with wait enabled but no interval specified."""
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
+
+    exec_context.set_env(
+        {
+            "GITHUB_ACTIONS": "true",
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "INPUT_LOCATION_NAME": "some-location",
+            "INPUT_REPOSITORY_NAME": "some-repository",
+            "INPUT_JOB_NAME": "some-job",
+            "INPUT_TAGS_JSON": "some-tags",
+            "INPUT_CONFIG_JSON": "some-config-json",
+            "INPUT_WAIT": "true",
+            # Note: No INPUT_INTERVAL set
+            "GITHUB_OUTPUT": output_file.name,
+        }
+    )
+
+    # Mock the multi-line output that dagster-cloud CLI produces with --wait (no interval)
+    multi_line_output = """Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 is in progress (status: STARTING)...
+Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 is in progress (status: STARTED)...
+Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
+
+    exec_context.stub_command(
+        "dagster-cloud",
+        {
+            "job launch --url http://dagster.cloud/test "
+            "--deployment prod "
+            "--api-token api-token "
+            "--location some-location "
+            "--repository some-repository "
+            "--job some-job "
+            "--tags some-tags "
+            "--config-json some-config-json "
+            "--wait": multi_line_output,
+        },
+    )
+    exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+    stdout = exec_context.get_stdout()
+    
+    assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
+    assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
+
+
+def test_run_interval_without_wait_fails(tmp_path, exec_context, action_docker_image_id):
+    """Test that using interval without wait fails with error."""
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
+
+    exec_context.set_env(
+        {
+            "GITHUB_ACTIONS": "true",
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "INPUT_LOCATION_NAME": "some-location",
+            "INPUT_REPOSITORY_NAME": "some-repository",
+            "INPUT_JOB_NAME": "some-job",
+            "INPUT_TAGS_JSON": "some-tags",
+            "INPUT_CONFIG_JSON": "some-config-json",
+            "INPUT_WAIT": "false",
+            "INPUT_INTERVAL": "10",  # This should cause an error
+            "GITHUB_OUTPUT": output_file.name,
+        }
+    )
+
+    # No need to stub command since it should fail before calling dagster-cloud
+    try:
+        exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+        assert False, "Expected command to fail"
+    except ValueError:
+        # Check that the error contains our expected message
+        stdout = exec_context.get_stdout()
+        assert "ERROR: interval parameter can only be used when wait is true" in stdout
+
+
 # Keep the original test for backwards compatibility
 def test_run(tmp_path, exec_context, action_docker_image_id):
     """Original test maintained for backwards compatibility."""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -36,6 +36,7 @@ def test_run_without_wait(tmp_path, exec_context, action_docker_image_id):
     stdout = exec_context.get_stdout()
     
     assert "Launching dagster-cloud job..." in stdout
+    assert "ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout  # Should appear in streamed output
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -35,7 +35,6 @@ def test_run_without_wait(tmp_path, exec_context, action_docker_image_id):
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
-    assert "DEBUG: Wait flag disabled" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -84,55 +83,50 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
-    assert "DEBUG: Wait flag enabled" in stdout
-    assert "DEBUG: Extracted run ID from status output: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
 
 def test_run_with_wait_various_values(tmp_path, exec_context, action_docker_image_id):
     """Test that various truthy values for wait parameter work."""
-    for wait_value in ["True", "TRUE", "1", "yes", "Yes", "YES", "on"]:
-        output_file = tmp_path / "output.txt"
-        output_file.touch()
+    output_file = tmp_path / "output.txt"
+    output_file.touch()
         
-        # Reset exec_context for each iteration
-        exec_context.reset()
-        exec_context.set_env(
-            {
-                "GITHUB_ACTIONS": "true",
-                "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
-                "INPUT_DEPLOYMENT": "prod",
-                "DAGSTER_CLOUD_API_TOKEN": "api-token",
-                "INPUT_LOCATION_NAME": "some-location",
-                "INPUT_REPOSITORY_NAME": "some-repository",
-                "INPUT_JOB_NAME": "some-job",
-                "INPUT_TAGS_JSON": "some-tags",
-                "INPUT_CONFIG_JSON": "some-config-json",
-                "INPUT_WAIT": wait_value,
-                "GITHUB_OUTPUT": output_file.name,
-            }
-        )
+    exec_context.set_env(
+        {
+            "GITHUB_ACTIONS": "true",
+            "DAGSTER_CLOUD_URL": "http://dagster.cloud/test",
+            "INPUT_DEPLOYMENT": "prod",
+            "DAGSTER_CLOUD_API_TOKEN": "api-token",
+            "INPUT_LOCATION_NAME": "some-location",
+            "INPUT_REPOSITORY_NAME": "some-repository",
+            "INPUT_JOB_NAME": "some-job",
+            "INPUT_TAGS_JSON": "some-tags",
+            "INPUT_CONFIG_JSON": "some-config-json",
+            "INPUT_WAIT": "TRUE",  # Test uppercase
+            "GITHUB_OUTPUT": output_file.name,
+        }
+    )
 
-        exec_context.stub_command(
-            "dagster-cloud",
-            {
-                "job launch --url http://dagster.cloud/test "
-                "--deployment prod "
-                "--api-token api-token "
-                "--location some-location "
-                "--repository some-repository "
-                "--job some-job "
-                "--tags some-tags "
-                "--config-json some-config-json "
-                "--wait": "Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully.",
-            },
-        )
-        exec_context.run_docker_command(action_docker_image_id, "/run.sh")
-        stdout = exec_context.get_stdout()
-        
-        assert "DEBUG: Wait flag enabled" in stdout, f"Failed for wait_value: {wait_value}"
-        break  # Only test one value since exec_context can only run once
+    exec_context.stub_command(
+        "dagster-cloud",
+        {
+            "job launch --url http://dagster.cloud/test "
+            "--deployment prod "
+            "--api-token api-token "
+            "--location some-location "
+            "--repository some-repository "
+            "--job some-job "
+            "--tags some-tags "
+            "--config-json some-config-json "
+            "--wait": "Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully.",
+        },
+    )
+    exec_context.run_docker_command(action_docker_image_id, "/run.sh")
+    stdout = exec_context.get_stdout()
+    
+    assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
+    assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
 
 def test_run_legacy_compatibility(tmp_path, exec_context, action_docker_image_id):
@@ -172,7 +166,6 @@ def test_run_legacy_compatibility(tmp_path, exec_context, action_docker_image_id
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
-    assert "DEBUG: Wait flag disabled" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -36,7 +36,7 @@ def test_run_without_wait(tmp_path, exec_context, action_docker_image_id):
     stdout = exec_context.get_stdout()
     
     assert "Launching dagster-cloud job..." in stdout
-    assert "ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout  # Should appear in streamed output
+    assert "Command flags: wait_flag='' interval_flag=''" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -86,6 +86,7 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     stdout = exec_context.get_stdout()
     
     assert "Launching dagster-cloud job..." in stdout
+    assert "Command flags: wait_flag='--wait' interval_flag=''" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -221,6 +222,7 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     stdout = exec_context.get_stdout()
     
     assert "Launching dagster-cloud job..." in stdout
+    assert "Command flags: wait_flag='--wait' interval_flag='--interval 10'" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -35,6 +35,7 @@ def test_run_without_wait(tmp_path, exec_context, action_docker_image_id):
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
+    assert "Launching dagster-cloud job..." in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -83,6 +84,7 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
+    assert "Launching dagster-cloud job..." in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -125,6 +127,7 @@ def test_run_with_wait_various_values(tmp_path, exec_context, action_docker_imag
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
+    assert "Launching dagster-cloud job..." in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -166,6 +169,7 @@ def test_run_legacy_compatibility(tmp_path, exec_context, action_docker_image_id
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
+    assert "Launching dagster-cloud job..." in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -215,6 +219,7 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
+    assert "Launching dagster-cloud job..." in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -263,6 +268,7 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
     stdout = exec_context.get_stdout()
     
+    assert "Launching dagster-cloud job..." in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -334,5 +340,7 @@ def test_run(tmp_path, exec_context, action_docker_image_id):
         },
     )
     exec_context.run_docker_command(action_docker_image_id, "/run.sh")
-    assert "Successfully launched run: some-run" in exec_context.get_stdout()
+    stdout = exec_context.get_stdout()
+    assert "Launching dagster-cloud job..." in stdout
+    assert "Successfully launched run: some-run" in stdout
     assert "run_id=some-run" in output_file.read_text()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -36,7 +36,6 @@ def test_run_without_wait(tmp_path, exec_context, action_docker_image_id):
     stdout = exec_context.get_stdout()
     
     assert "Launching dagster-cloud job..." in stdout
-    assert "Command flags: wait_flag='' interval_flag=''" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -86,7 +85,6 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     stdout = exec_context.get_stdout()
     
     assert "Launching dagster-cloud job..." in stdout
-    assert "Command flags: wait_flag='--wait' interval_flag=''" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 
@@ -222,7 +220,6 @@ Run ee1ecc27-1dbe-435d-bd62-c2b1c491eef6 finished successfully."""
     stdout = exec_context.get_stdout()
     
     assert "Launching dagster-cloud job..." in stdout
-    assert "Command flags: wait_flag='--wait' interval_flag='--interval 10'" in stdout
     assert "Successfully launched run: ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in stdout
     assert "run_id=ee1ecc27-1dbe-435d-bd62-c2b1c491eef6" in output_file.read_text()
 


### PR DESCRIPTION
Adds support to `dagster-cloud-actions/utils/run` for the --wait flag (which was the only parameter _not_ supported by the GitHub action that was in the dagster-cloud job launch. This way, if the action is used as part of a CI workload, the CI can wait until that Dagster job is complete (common for example with dbt slim CI setups)

## Test plan

* Added new unit tests to mock the run output for a sigle-line output (`--wait` flag not present or false on the github action) and multi-line (when `--wait` is present).
* Deployed to the `add-wait-param` tag for the `dagster-cloud-action` package in GitHub and tested in hooli to validate that it works on a real invocation with both `wait: true` and wait not specified (the default).

I didn't add support for `--interval` but I have uncommitted code that adds it, I just didn't do so here because it's untested. Happy to push that up for completeness