### PR TITLE
[dagster-cloud-action] automatically bump version action tag

### DIFF
--- a/github/serverless/branch_deployments.yml
+++ b/github/serverless/branch_deployments.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - name: Prerun Checks
         id: prerun
-        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
 
       - name: Launch Docker Deploy
         if: steps.prerun.outputs.result == 'docker-deploy'
         id: parse-workspace
-        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
         with:
           dagster_cloud_file: $DAGSTER_CLOUD_FILE
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v0.1
         with:
           dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_CLOUD_FILE"
           build_output_dir: "$GITHUB_WORKSPACE/build"
@@ -65,7 +65,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless
-        uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v0.1
         with:
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}

--- a/github/serverless/dbt/branch_deployments.yml
+++ b/github/serverless/dbt/branch_deployments.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
       - name: Prerun Checks
         id: prerun
-        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
 
       - name: Launch Docker Deploy
         if: steps.prerun.outputs.result == 'docker-deploy'
         id: parse-workspace
-        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
         with:
           dagster_cloud_file: $DAGSTER_CLOUD_FILE
 
@@ -45,7 +45,7 @@ jobs:
       - name: Validate configuration
         id: ci-validate
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1
         with:
           command: "ci check --project-dir project-repo --dagster-cloud-yaml-path ${{ env.DAGSTER_CLOUD_FILE }}"
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Initialize build session
         id: ci-init
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/utils/ci-init@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/ci-init@v0.1
         with:
           project_dir: project-repo
           dagster_cloud_yaml_path: ${{ env.DAGSTER_CLOUD_FILE }}
@@ -74,7 +74,7 @@ jobs:
 
       - name: Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v0.1
         with:
           dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_CLOUD_FILE"
           build_output_dir: "$GITHUB_WORKSPACE/build"
@@ -97,7 +97,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless
-        uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v0.1
         with:
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}

--- a/github/serverless/dbt/deploy.yml
+++ b/github/serverless/dbt/deploy.yml
@@ -28,12 +28,12 @@ jobs:
     steps:
       - name: Prerun Checks
         id: prerun
-        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
 
       - name: Launch Docker Deploy
         if: steps.prerun.outputs.result == 'docker-deploy'
         id: parse-workspace
-        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
         with:
           dagster_cloud_file: $DAGSTER_CLOUD_FILE
 
@@ -47,14 +47,14 @@ jobs:
       - name: Validate configuration
         id: ci-validate
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1
         with:
           command: "ci check --project-dir project-repo --dagster-cloud-yaml-path ${{ env.DAGSTER_CLOUD_FILE }}"
 
       - name: Initialize build session
         id: ci-init
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/utils/ci-init@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/ci-init@v0.1
         with:
           project_dir: project-repo
           dagster_cloud_yaml_path: ${{ env.DAGSTER_CLOUD_FILE }}
@@ -74,7 +74,7 @@ jobs:
 
       - name: Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v0.1
         with:
           dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_CLOUD_FILE"
           build_output_dir: "$GITHUB_WORKSPACE/build"
@@ -97,7 +97,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless
-        uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v0.1
         with:
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}

--- a/github/serverless/deploy.yml
+++ b/github/serverless/deploy.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
       - name: Prerun Checks
         id: prerun
-        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
 
       - name: Launch Docker Deploy
         if: steps.prerun.outputs.result == 'docker-deploy'
         id: parse-workspace
-        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
         with:
           dagster_cloud_file: $DAGSTER_CLOUD_FILE
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v0.1
         with:
           dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_CLOUD_FILE"
           build_output_dir: "$GITHUB_WORKSPACE/build"
@@ -67,7 +67,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless
-        uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v1.11.12
+        uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v0.1
         with:
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}


### PR DESCRIPTION
Closes ADOPT-1920

After chatting with @gibsondan a bit more, we think it would be better to keep the `v0.1` and then dynamically update it to the latest version on the release branch creation following the same pattern as the Docker image tag.

You can find an example of the updated Docker tag for a release here:

* https://github.com/dagster-io/dagster-cloud-action/blob/release-1.11.13/gitlab/hybrid-ci.yml#L32

```
▸ uv run scripts/release.py update-action-version-references 1.11.12
Updating action version references to v1.11.12
github/serverless/branch_deployments.yml
github/serverless/deploy.yml
github/serverless/dbt/branch_deployments.yml
github/serverless/dbt/deploy.yml

▸ git diff .
diff --git a/github/serverless/branch_deployments.yml b/github/serverless/branch_deployments.yml
index 30d2c9a..ac3e565 100644
--- a/github/serverless/branch_deployments.yml
+++ b/github/serverless/branch_deployments.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - name: Prerun Checks
         id: prerun
-        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.11.12

       - name: Launch Docker Deploy
         if: steps.prerun.outputs.result == 'docker-deploy'
         id: parse-workspace
-        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.11.12
         with:
           dagster_cloud_file: $DAGSTER_CLOUD_FILE

@@ -42,7 +42,7 @@ jobs:

       - name: Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/build_deploy_python_executable@v1.11.12
         with:
           dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/$DAGSTER_CLOUD_FILE"
           build_output_dir: "$GITHUB_WORKSPACE/build"
@@ -65,7 +65,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless
-        uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/serverless_branch_deploy@v1.11.12
         with:
           dagster_cloud_api_token: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
           location: ${{ toJson(matrix.location) }}
diff --git a/github/serverless/dbt/branch_deployments.yml b/github/serverless/dbt/branch_deployments.yml
index 277bcbb..038cf06 100644
--- a/github/serverless/dbt/branch_deployments.yml
+++ b/github/serverless/dbt/branch_deployments.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
       - name: Prerun Checks
         id: prerun
-        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.11.12

       - name: Launch Docker Deploy
         if: steps.prerun.outputs.result == 'docker-deploy'
         id: parse-workspace
-        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/utils/parse_workspace@v1.11.12
         with:
           dagster_cloud_file: $DAGSTER_CLOUD_FILE
```