### PR TITLE
Upgrade GitHub Actions to checkout/setup-python v6

### DIFF
--- a/.github/workflows/hybrid_branch_deployments.yml
+++ b/.github/workflows/hybrid_branch_deployments.yml
@@ -12,7 +12,7 @@ jobs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
       secrets_set: ${{ steps.parse-workspace.outputs.secrets_set }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Parse cloud workspace
         id: parse-workspace
         uses: ./actions/utils/parse_workspace
@@ -29,7 +29,7 @@ jobs:
         location: ${{ fromJSON(needs.parse_workspace.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/hybrid_deploy.yml
+++ b/.github/workflows/hybrid_deploy.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Parse cloud workspace
         id: parse-workspace
         uses: ./actions/utils/parse_workspace
@@ -30,7 +30,7 @@ jobs:
         location: ${{ fromJSON(needs.parse_workspace.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/serverless_branch_custom_base_image.yml
+++ b/.github/workflows/serverless_branch_custom_base_image.yml
@@ -12,7 +12,7 @@ jobs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
       secrets_set: ${{ steps.parse-workspace.outputs.secrets_set }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Parse cloud workspace
         id: parse-workspace
         uses: ./actions/utils/parse_workspace
@@ -29,7 +29,7 @@ jobs:
         location: ${{ fromJSON(needs.parse_workspace.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/.github/workflows/serverless_branch_deployments.yml
+++ b/.github/workflows/serverless_branch_deployments.yml
@@ -12,7 +12,7 @@ jobs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
       secrets_set: ${{ steps.parse-workspace.outputs.secrets_set }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Parse cloud workspace
         id: parse-workspace
         uses: ./actions/utils/parse_workspace
@@ -29,7 +29,7 @@ jobs:
         location: ${{ fromJSON(needs.parse_workspace.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/.github/workflows/serverless_custom_image.yml
+++ b/.github/workflows/serverless_custom_image.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Parse cloud workspace
         id: parse-workspace
         uses: ./actions/utils/parse_workspace
@@ -30,7 +30,7 @@ jobs:
         location: ${{ fromJSON(needs.parse_workspace.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/.github/workflows/serverless_deploy.yml
+++ b/.github/workflows/serverless_deploy.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       build_info: ${{ steps.parse-workspace.outputs.build_info }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Parse cloud workspace
         id: parse-workspace
         uses: ./actions/utils/parse_workspace
@@ -30,7 +30,7 @@ jobs:
         location: ${{ fromJSON(needs.parse_workspace.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/.github/workflows/serverless_launch_job_definitions.yml
+++ b/.github/workflows/serverless_launch_job_definitions.yml
@@ -11,7 +11,7 @@ jobs:
     name: Dagster Serverless Job Launch
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
       - name: Launch a job on Dagster Cloud serverless

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     name: PyTest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/actions/build_deploy_python_executable/action.yml
+++ b/actions/build_deploy_python_executable/action.yml
@@ -47,7 +47,7 @@ runs:
 
     - id: setup-python
       name: Set up Python ${{ inputs.python_version }} for target
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -25,12 +25,12 @@ runs:
   steps:
     - name: Checkout target repo
       if: inputs.checkout_repo == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.sha }}
 
     - name: Checkout action repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: dagster-io/dagster-cloud-action
         ref: ${{ env.DAGSTER_ACTION_REF }}

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -25,12 +25,12 @@ runs:
   steps:
     - name: Checkout target repo
       if: inputs.checkout_repo == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.sha }}
 
     - name: Checkout action repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: dagster-io/dagster-cloud-action
         ref: ${{ env.DAGSTER_ACTION_REF }}

--- a/actions/launch_job/action.yml
+++ b/actions/launch_job/action.yml
@@ -34,12 +34,12 @@ runs:
   using: "composite"
   steps:
     - name: Checkout target repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.sha }}
 
     - name: Checkout action repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: dagster-io/dagster-cloud-action
         ref: ${{ env.DAGSTER_ACTION_REF }}

--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -30,12 +30,12 @@ runs:
   steps:
     - name: Checkout target repo
       if:  inputs.checkout_repo == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.sha }}
 
     - name: Checkout action repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: dagster-io/dagster-cloud-action
         ref: ${{ env.DAGSTER_ACTION_REF }}

--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -30,12 +30,12 @@ runs:
   steps:
     - name: Checkout target repo
       if: inputs.checkout_repo == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.sha }}
 
     - name: Checkout action repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: dagster-io/dagster-cloud-action
         ref: ${{ env.DAGSTER_ACTION_REF }}

--- a/actions/utils/parse_workspace/action.yml
+++ b/actions/utils/parse_workspace/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout target repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.sha }}
 

--- a/actions/utils/prerun/action.yml
+++ b/actions/utils/prerun/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Checking out the commit sha should always work. For closed PRs with deleted branches,
         # this checks out the sha of the merge commit.
@@ -37,4 +37,3 @@ runs:
         echo 'PR not closed (or not in a PR)' &&
         if [ ${ENABLE_FAST_DEPLOYS:-false} == "true" ]; then echo "result=pex-deploy"; else echo "result=docker-deploy"; fi >> "$GITHUB_OUTPUT"
       shell: bash
-

--- a/github/serverless/branch_deployments.yml
+++ b/github/serverless/branch_deployments.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Checkout for Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
@@ -61,7 +61,7 @@ jobs:
         location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/github/serverless/dbt/branch_deployments.yml
+++ b/github/serverless/dbt/branch_deployments.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
@@ -93,7 +93,7 @@ jobs:
         location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/github/serverless/dbt/deploy.yml
+++ b/github/serverless/dbt/deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Checkout
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
@@ -93,7 +93,7 @@ jobs:
         location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/github/serverless/deploy.yml
+++ b/github/serverless/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout for Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
@@ -63,7 +63,7 @@ jobs:
         location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless


### PR DESCRIPTION
Addresses: #246 

My team is currently updating all of our GitHub Actions to stop using Node.js 20, and the official Dagster actions are still triggering deprecation warnings. This PR updates the affected actions to newer supported versions.