### PR TITLE
Add create-pinned-release workflow and standalone pin_actions script

### DIFF
--- a/.github/workflows/create_pinned_release.yml
+++ b/.github/workflows/create_pinned_release.yml
@@ -1,0 +1,91 @@
+name: Create Pinned Release
+# Creates a "-pinned" variant of an existing release tag: checks out the base
+# tag, pins all third-party action references to commit SHAs, rewrites
+# dagster-cloud-action self-references to the new tag, and pushes the result
+# as a new tag. The base tag is never modified.
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: "Existing release tag to pin (e.g. v1.13.6)"
+        required: true
+      new_tag:
+        description: "Tag to create (default: <base_tag>-pinned)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  create-pinned-release:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the workflow's own ref first: base tags cut before this
+      # workflow landed do not contain scripts/pin_actions.py.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install typer rich
+
+      - name: Compute new tag
+        id: tag
+        run: |
+          NEW_TAG="${{ inputs.new_tag }}"
+          if [ -z "$NEW_TAG" ]; then
+            NEW_TAG="${{ inputs.base_tag }}-pinned"
+          fi
+          if git rev-parse "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $NEW_TAG already exists"
+            exit 1
+          fi
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          # release.py update-action-version-references prepends "v" itself
+          echo "new_version=${NEW_TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Stash pin script and check out base tag
+        run: |
+          cp scripts/pin_actions.py /tmp/pin_actions.py
+          git checkout "${{ inputs.base_tag }}"
+
+      - name: Pin third-party actions to SHAs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python /tmp/pin_actions.py --repo-dir "$GITHUB_WORKSPACE"
+
+      # Uses the base tag's own release.py, the same code path the release
+      # pipeline runs (present in all recent releases).
+      - name: Update self-references to new tag
+        run: |
+          python scripts/release.py update-action-version-references \
+            "${{ steps.tag.outputs.new_version }}"
+
+      - name: Verify all third-party refs are pinned
+        run: python /tmp/pin_actions.py --check --repo-dir "$GITHUB_WORKSPACE"
+
+      - name: Commit and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --cached --quiet && { echo "::error::No changes produced"; exit 1; }
+          git commit -m "Pinned release ${{ steps.tag.outputs.new_tag }} (base: ${{ inputs.base_tag }})"
+          git tag -a "${{ steps.tag.outputs.new_tag }}" \
+            -m "Pinned release ${{ steps.tag.outputs.new_tag }} (base: ${{ inputs.base_tag }})"
+          git push origin "${{ steps.tag.outputs.new_tag }}"
+
+      - name: Summary
+        run: |
+          echo "Created tag ${{ steps.tag.outputs.new_tag }} from ${{ inputs.base_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          git show --stat HEAD >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/PINNED_RELEASES.md
+++ b/PINNED_RELEASES.md
@@ -1,0 +1,112 @@
+# Pinned releases
+
+Pinned releases are variants of regular `dagster-cloud-action` releases in which
+every **third-party** GitHub Action reference is pinned to a full commit SHA
+instead of a mutable tag:
+
+```yaml
+# regular release (v1.13.8)
+- uses: actions/checkout@v4
+
+# pinned release (v1.13.8-pinned)
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+```
+
+A tag like `actions/checkout@v4` can be re-pointed at any time by whoever
+controls that repository; a commit SHA cannot. Pinning closes off the
+supply-chain risk of a compromised or hijacked third-party action being pulled
+into your deploys.
+
+A pinned release is built from an existing release tag (e.g. `v1.13.8`) and
+published as `<base_tag>-pinned` (e.g. `v1.13.8-pinned`). The base tag is never
+modified, and the pinned variant reuses the base release's binaries — no
+rebuild happens.
+
+## Using a pinned release
+
+### 1. Pick a pinned release and resolve its commit SHA
+
+```bash
+# list available pinned tags
+git ls-remote --tags https://github.com/dagster-io/dagster-cloud-action 'refs/tags/*-pinned'
+
+# resolve a pinned tag to its commit SHA
+gh api repos/dagster-io/dagster-cloud-action/commits/v1.13.8-pinned --jq .sha
+```
+
+Note: use the command above (or the commit shown on the release page), not
+`git ls-remote`'s tag object SHA — annotated tags have their own SHA distinct
+from the commit they point to, and `uses:` needs the **commit** SHA.
+
+### 2. Update your workflow files
+
+In your repository's `.github/workflows/*.yml`, replace each
+`dagster-io/dagster-cloud-action` version tag with the commit SHA, keeping the
+tag as a comment for readability:
+
+```yaml
+# before
+- uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@v1.13.8
+
+# after
+- uses: dagster-io/dagster-cloud-action/actions/serverless_prod_deploy@83e0bb0323b0a0d136b815d049261bddcbd8963d # v1.13.8-pinned
+```
+
+All `actions/...` subpaths use the same SHA — it identifies the whole
+repository tree at that release. With `sed`:
+
+```bash
+SHA=$(gh api repos/dagster-io/dagster-cloud-action/commits/v1.13.8-pinned --jq .sha)
+sed -i '' -E \
+  "s|(dagster-io/dagster-cloud-action[^@[:space:]]*)@v[0-9][^[:space:]]*|\1@${SHA} # v1.13.8-pinned|" \
+  .github/workflows/*.yml
+```
+
+(On Linux use `sed -i -E ...` without the `''`.)
+
+While you're at it, consider pinning the *other* third-party actions in your
+workflows the same way (`actions/checkout`, etc.) —
+[`scripts/pin_actions.py`](scripts/pin_actions.py) shows the pattern, and tools
+like [zizmor](https://github.com/woodruffw/zizmor) or
+[ratchet](https://github.com/sethvargo/ratchet) can do it for arbitrary repos.
+
+### 3. Verify
+
+Trigger a branch deploy (or any workflow run) and confirm it succeeds. The run
+logs show each action resolved at the pinned SHA.
+
+## What is and isn't pinned
+
+| Layer | Pinned? |
+| --- | --- |
+| Your `uses: dagster-io/dagster-cloud-action/...@<SHA>` reference | ✅ immutable commit SHA |
+| Third-party actions inside the pinned release | ✅ immutable commit SHAs |
+| `dagster-cloud` PEX binaries | ✅ committed files in the pinned tree |
+| `ghcr.io/dagster-io/dagster-cloud-action:<version>` Docker image | ⚠️ referenced by version tag, not digest |
+
+The Docker image tag is the one remaining mutable reference; pinning images to
+`@sha256:` digests is a possible future extension of the pinning script.
+
+## Creating a pinned release
+
+Maintainers can create a pinned variant of any existing release tag:
+
+- **GitHub UI / CLI** (once the `Create Pinned Release` workflow is on `main`):
+
+  ```bash
+  gh workflow run create_pinned_release.yml -f base_tag=v1.13.8
+  ```
+
+  Optional `-f new_tag=...` overrides the default `<base_tag>-pinned` name.
+
+- **Locally**:
+
+  ```bash
+  scripts/create_pinned_release.sh v1.13.8
+  ```
+
+Both paths run the same sequence: check out the base tag, pin third-party
+refs to SHAs (`scripts/pin_actions.py`), rewrite
+`dagster-io/dagster-cloud-action` self-references to the new tag, run a
+YAML-parse verification gate (`pin_actions.py --check`), then commit and push
+only the new tag.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [GitHub Actions](https://docs.github.com/en/actions) to deploy code locations to Dagster Cloud.
 
+## Pinned releases
+
+Releases tagged `<version>-pinned` (e.g. `v1.13.8-pinned`) have all third-party
+action references pinned to commit SHAs for supply-chain hardening. See
+[PINNED_RELEASES.md](PINNED_RELEASES.md) for how to use them and how to create one.
+
 ## Quickstart example repositories
 
 To get started using GitHub Actions-driven CI/CD for Dagster Cloud, take a look at our quickstart example repositories.

--- a/scripts/create_pinned_release.sh
+++ b/scripts/create_pinned_release.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Create a "-pinned" variant of an existing release tag, locally.
+#
+# Mirrors .github/workflows/create_pinned_release.yml: checks out the base
+# tag, pins all third-party GitHub Action references to commit SHAs, rewrites
+# dagster-cloud-action self-references to the new tag, verifies, then commits
+# and pushes the result as a new tag. The base tag is never modified.
+#
+# Usage:
+#   scripts/create_pinned_release.sh <base_tag> [new_tag]
+#
+#   base_tag  Existing release tag to pin (e.g. v1.13.8)
+#   new_tag   Tag to create (default: <base_tag>-pinned)
+#
+# Requirements: git, uv, and either GITHUB_TOKEN set or `gh` authenticated.
+# Run from a checkout that contains scripts/pin_actions.py (e.g. main once
+# the workflow has landed, or the feature branch).
+
+set -euo pipefail
+
+# The whole script is wrapped in main() so bash parses the entire file before
+# executing anything — `git checkout <base_tag>` below changes the file tree
+# this script may live in, and bash otherwise reads scripts incrementally.
+main() {
+    local base_tag="${1:?usage: $0 <base_tag> [new_tag]}"
+    local new_tag="${2:-${base_tag}-pinned}"
+    local new_version="${new_tag#v}"  # release.py prepends the "v" itself
+
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel)"
+    cd "$repo_root"
+
+    # --- Preflight ----------------------------------------------------------
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "ERROR: working tree not clean; commit or stash first" >&2
+        exit 1
+    fi
+    if ! git rev-parse -q --verify "refs/tags/${base_tag}" > /dev/null; then
+        echo "ERROR: base tag ${base_tag} not found (try: git fetch --tags)" >&2
+        exit 1
+    fi
+    if git rev-parse -q --verify "refs/tags/${new_tag}" > /dev/null; then
+        echo "ERROR: tag ${new_tag} already exists locally" >&2
+        exit 1
+    fi
+    if [[ -n "$(git ls-remote --tags origin "refs/tags/${new_tag}")" ]]; then
+        echo "ERROR: tag ${new_tag} already exists on origin" >&2
+        exit 1
+    fi
+    if [[ ! -f scripts/pin_actions.py ]]; then
+        echo "ERROR: scripts/pin_actions.py not in current checkout;" \
+             "run from a ref that contains it" >&2
+        exit 1
+    fi
+
+    if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+        GITHUB_TOKEN="$(gh auth token)"
+        export GITHUB_TOKEN
+    fi
+
+    # Remember where we started so we can return afterwards.
+    local original_ref
+    original_ref="$(git symbolic-ref --short -q HEAD || git rev-parse HEAD)"
+
+    # Base tags cut before the pin script landed don't contain it, so run a
+    # copy from outside the worktree.
+    local pin_script
+    pin_script="$(mktemp -t pin_actions.XXXXXX.py)"
+    cp scripts/pin_actions.py "$pin_script"
+
+    echo "==> Checking out ${base_tag}"
+    git checkout -q "$base_tag"
+
+    echo "==> Pinning third-party action refs to SHAs"
+    uv run -q --with requests --with PyYAML \
+        python3 "$pin_script" --repo-dir "$repo_root"
+
+    echo "==> Rewriting self-references to ${new_tag}"
+    # Uses the base tag's own release.py, the same code path the release
+    # pipeline runs.
+    uv run -q --with typer --with rich \
+        python3 scripts/release.py update-action-version-references "$new_version"
+
+    echo "==> Verifying all third-party refs are pinned"
+    uv run -q --with requests --with PyYAML \
+        python3 "$pin_script" --check --repo-dir "$repo_root"
+
+    echo "==> Committing and tagging ${new_tag}"
+    git add .
+    if git diff --cached --quiet; then
+        echo "ERROR: no changes produced; is ${base_tag} already pinned?" >&2
+        git checkout -q "$original_ref"
+        exit 1
+    fi
+    git commit -q -m "Pinned release ${new_tag} (base: ${base_tag})"
+    git tag -a "$new_tag" -m "Pinned release ${new_tag} (base: ${base_tag})"
+
+    echo
+    git show --stat HEAD | head -40
+    echo
+    read -r -p "Push ${new_tag} to origin? [y/N] " answer
+    if [[ "$answer" == [yY]* ]]; then
+        git push origin "$new_tag"
+        echo "==> Pushed ${new_tag}"
+    else
+        echo "==> Not pushed. Push later with: git push origin ${new_tag}"
+    fi
+
+    # The commit is retained by the tag; safe to leave detached HEAD.
+    git checkout -q "$original_ref"
+    rm -f "$pin_script"
+    echo "==> Done. Back on ${original_ref}."
+}
+
+main "$@"

--- a/scripts/pin_actions.py
+++ b/scripts/pin_actions.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Pin third-party GitHub Action references to commit SHAs.
+
+Walks YAML files in the repo, finds `uses: owner/repo@tag` references,
+resolves each tag to a SHA via the GitHub API, and replaces with
+`uses: owner/repo@SHA # tag`.
+
+Skips local path references (./), self-references (dagster-io/dagster-cloud-action),
+and references already pinned to a SHA. Re-running is a no-op.
+
+Usage:
+    python scripts/pin_actions.py [--repo-dir DIR] [--dry-run]
+    python scripts/pin_actions.py --check [--repo-dir DIR]
+
+--check does not modify anything: it parses every YAML file (rather than
+regex-scanning it) and exits non-zero if any third-party `uses:` reference is
+not pinned to a full commit SHA. Used as a verification gate after pinning.
+
+Authentication uses GITHUB_TOKEN from the environment if set (recommended in CI
+to avoid rate limits); falls back to unauthenticated requests.
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+import requests
+import yaml
+
+SELF_REPO = "dagster-io/dagster-cloud-action"
+
+# Matches: uses: owner/repo@ref  or  uses: owner/repo/path@ref
+# Captures: (1) prefix "uses: ", (2) full action path, (3) owner/repo, (4) optional /subpath, (5) ref
+ACTION_USES_RE = re.compile(
+    r"(uses:\s+)"  # group 1: "uses:" + whitespace
+    r"(([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)"  # group 2 start + group 3: owner/repo
+    r"(/[^\s@]*)?)"  # group 4: optional /subpath; closes group 2
+    r"@([^\s#]+)"  # group 5: ref (everything after @ until whitespace or #)
+)
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def resolve_ref_to_sha(owner_repo: str, ref: str, github_token: str | None) -> str:
+    """Resolve a GitHub action ref (tag/branch) to its commit SHA."""
+    headers = {"Accept": "application/vnd.github+json"}
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+    response = requests.get(
+        f"https://api.github.com/repos/{owner_repo}/commits/{ref}",
+        headers=headers,
+    )
+    response.raise_for_status()
+    return response.json()["sha"]
+
+
+def find_yaml_files(repo_dir: str) -> list:
+    # Note: pathlib.rglob (unlike glob.glob) descends into hidden directories,
+    # which matters for .github/workflows/.
+    root = Path(repo_dir)
+    return sorted(
+        str(p)
+        for p in set(root.rglob("*.yml")) | set(root.rglob("*.yaml"))
+        if ".git" not in p.relative_to(root).parts  # skip the git object dir itself
+    )
+
+
+def collect_refs_to_resolve(yaml_files: list) -> dict:
+    """Collect unique (owner/repo, ref) pairs that need pinning."""
+    refs_to_resolve = {}
+    for filepath in yaml_files:
+        with open(filepath, encoding="utf-8") as f:
+            content = f.read()
+        for match in ACTION_USES_RE.finditer(content):
+            owner_repo = match.group(3)
+            ref = match.group(5)
+            if owner_repo == SELF_REPO:
+                continue
+            if SHA_RE.match(ref):
+                continue
+            refs_to_resolve.setdefault((owner_repo, ref), "")
+    return refs_to_resolve
+
+
+def pin_third_party_actions_to_shas(
+    repo_dir: str, github_token: str | None, dry_run: bool = False
+) -> int:
+    """Pin third-party action refs in repo_dir. Returns the number of files changed."""
+    yaml_files = find_yaml_files(repo_dir)
+    refs_to_resolve = collect_refs_to_resolve(yaml_files)
+
+    for owner_repo, ref in refs_to_resolve:
+        sha = resolve_ref_to_sha(owner_repo, ref, github_token)
+        refs_to_resolve[(owner_repo, ref)] = sha
+        print(f"Resolved {owner_repo}@{ref} -> {sha}")
+
+    changed = 0
+    for filepath in yaml_files:
+        with open(filepath, encoding="utf-8") as f:
+            content = f.read()
+
+        new_content = content
+        for (owner_repo, ref), sha in refs_to_resolve.items():
+            # Replace: owner/repo@ref and owner/repo/path@ref
+            # With: owner/repo@SHA # ref
+            new_content = re.sub(
+                rf"(uses:\s+{re.escape(owner_repo)}(?:/[^\s@]*)?)@{re.escape(ref)}",
+                rf"\1@{sha} # {ref}",
+                new_content,
+            )
+
+        if new_content != content:
+            changed += 1
+            if dry_run:
+                print(f"Would pin action refs in {filepath}")
+            else:
+                with open(filepath, "w", encoding="utf-8") as f:
+                    f.write(new_content)
+                print(f"Pinned action refs in {filepath}")
+
+    return changed
+
+
+class _LenientLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates unknown tags (e.g. GitLab's !reference)."""
+
+
+_LenientLoader.add_multi_constructor("", lambda loader, suffix, node: None)
+
+
+def _iter_uses_values(node):
+    """Yield every value of a `uses` key anywhere in a parsed YAML tree.
+
+    Walking the whole tree (rather than assuming workflow/composite-action
+    schemas) covers steps, reusable-workflow jobs, and composite actions alike.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "uses" and isinstance(value, str):
+                yield value
+            else:
+                yield from _iter_uses_values(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_uses_values(item)
+
+
+def check_all_actions_pinned(repo_dir: str) -> int:
+    """Verify every third-party `uses:` ref is SHA-pinned. Returns number of failures.
+
+    Parses YAML properly, so quoted refs, anchors, and odd formatting that a
+    regex scan could miss are all covered. Local paths (./) and
+    dagster-cloud-action self-references are allowed; docker:// refs without a
+    digest are reported as warnings (they cannot be SHA-pinned by this script).
+    """
+    failures = 0
+    for filepath in find_yaml_files(repo_dir):
+        with open(filepath, encoding="utf-8") as f:
+            try:
+                documents = list(yaml.load_all(f, Loader=_LenientLoader))
+            except yaml.YAMLError as err:
+                print(f"FAIL {filepath}: could not parse YAML: {err}")
+                failures += 1
+                continue
+
+        for document in documents:
+            for uses in _iter_uses_values(document):
+                if uses.startswith("./"):
+                    continue
+                if uses.startswith("docker://"):
+                    if "@sha256:" not in uses:
+                        print(f"WARN {filepath}: docker ref without digest: {uses}")
+                    continue
+                path_part, _, ref = uses.partition("@")
+                owner_repo = "/".join(path_part.split("/")[:2])
+                if owner_repo == SELF_REPO:
+                    continue
+                if not SHA_RE.match(ref):
+                    print(f"FAIL {filepath}: unpinned third-party ref: {uses}")
+                    failures += 1
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo-dir",
+        default=os.path.join(os.path.dirname(__file__), ".."),
+        help="Repository root to scan (default: this repo)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and report, but do not modify files",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify (via YAML parsing) that all third-party refs are SHA-pinned",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        failures = check_all_actions_pinned(os.path.abspath(args.repo_dir))
+        if failures:
+            print(f"Check failed: {failures} unpinned third-party reference(s)")
+            return 1
+        print("Check passed: all third-party action refs are pinned to SHAs")
+        return 0
+
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if not github_token:
+        print("Warning: GITHUB_TOKEN not set; using unauthenticated API requests", file=sys.stderr)
+
+    changed = pin_third_party_actions_to_shas(
+        os.path.abspath(args.repo_dir), github_token, dry_run=args.dry_run
+    )
+    print(f"{'Would change' if args.dry_run else 'Changed'} {changed} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## TL;DR

Adds a manual GHA workflow dispatch to create pinned versions. Also a script that can be called locally to do the same. It takes a tagged version and sets all of the underlying github actions with their sha's so it's pined to a commit and not to a tag for security purposes.

## Test plan

CI  + manually ran the deploy step locally and then ran a [hooli PR](https://github.com/dagster-io/hooli-data-eng-pipelines/pull/219) against the tag


## Summary

Adds a `workflow_dispatch` workflow that creates a **`-pinned` variant of an existing release tag**, with all third-party GitHub Action references pinned to commit SHAs.

- `scripts/pin_actions.py` — standalone pinning script (no Dagster deps; `requests`/`PyYAML` from `requirements.txt`):
  - Rewrites `uses: owner/repo@tag` → `uses: owner/repo@<sha> # tag` across all YAML files
  - Skips local paths, `dagster-io/dagster-cloud-action` self-references, and already-pinned refs (idempotent)
  - Uses `pathlib.rglob` so `.github/workflows/` is covered (hidden dirs are skipped by `glob.glob`)
  - `--check` mode: YAML-parse-based verification (immune to quoting/format edge cases regex misses) that fails if any third-party ref is not SHA-pinned; warns on `docker://` refs without digests
- `scripts/create_pinned_release.sh` — runs the same sequence locally (pin, self-ref rewrite, `--check` gate, commit, tag) with preflight checks and a confirmation prompt before pushing the tag; useful until the workflow is registered on the default branch, or whenever a local run is preferred
- `.github/workflows/create_pinned_release.yml` — `workflow_dispatch` with `base_tag` (required) and `new_tag` (default `<base_tag>-pinned`):
  1. Checks out the workflow's own ref (base tags predating this PR don't contain the pin script), stashes the script, then checks out `base_tag`
  2. Pins third-party refs to SHAs
  3. Rewrites self-references to the new tag via the base tag's own `release.py update-action-version-references`
  4. Verification gate: `pin_actions.py --check` must pass before anything is committed
  5. Commits and pushes only the new tag — the base tag is never modified

No registry pushes are needed: the pinned tag reuses the base release's committed PEX binaries and its existing `ghcr.io` image references.

## Test plan

Rehearsed the full sequence locally against `v1.13.8`:
- Dry-run: 7 unique third-party refs resolved, 21 files would change; self-refs/local/pinned refs untouched
- Full run from a stashed script copy against the bare `v1.13.8` tree (matching CI conditions): 20 files pinned, self-refs rewritten to `@v1.13.8-pinned`, `--check` gate passes
- `--check` on the unpinned tree correctly fails with 48 findings (exit 1); second pin run is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)
