### PR TITLE
fix: preserve $ in Harbor robot username through registry-info + docker login

### DIFF
--- a/actions/serverless_branch_deploy/action.yml
+++ b/actions/serverless_branch_deploy/action.yml
@@ -57,7 +57,12 @@ runs:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
 
     - name: Login to ECR
-      run: echo "${{ env.AWS_ECR_PASSWORD }}" | docker login --username ${{ env.AWS_ECR_USERNAME }} --password-stdin ${{  env.REGISTRY_URL  }}
+      # Read credentials from bash env, not from `${{ env.VAR }}` template
+      # substitution. The latter pastes the literal value into the bash
+      # script before bash runs, which causes a `$` in the username (e.g.
+      # Harbor robot accounts: robot$<project>+push) to be eaten as a
+      # variable expansion.
+      run: echo "$AWS_ECR_PASSWORD" | docker login --username "$AWS_ECR_USERNAME" --password-stdin "$REGISTRY_URL"
       shell: bash
 
     - name: Notify build start

--- a/actions/serverless_prod_deploy/action.yml
+++ b/actions/serverless_prod_deploy/action.yml
@@ -57,7 +57,12 @@ runs:
         DAGSTER_CLOUD_API_TOKEN: ${{ inputs.dagster_cloud_api_token }}
 
     - name: Login to ECR
-      run: echo "${{ env.AWS_ECR_PASSWORD }}" | docker login --username ${{ env.AWS_ECR_USERNAME }} --password-stdin ${{  env.REGISTRY_URL  }}
+      # Read credentials from bash env, not from `${{ env.VAR }}` template
+      # substitution. The latter pastes the literal value into the bash
+      # script before bash runs, which causes a `$` in the username (e.g.
+      # Harbor robot accounts: robot$<project>+push) to be eaten as a
+      # variable expansion.
+      run: echo "$AWS_ECR_PASSWORD" | docker login --username "$AWS_ECR_USERNAME" --password-stdin "$REGISTRY_URL"
       shell: bash
 
     - name: Set up Docker Buildx

--- a/src/registry_info.sh
+++ b/src/registry_info.sh
@@ -15,8 +15,23 @@ while (( !AWS_ECR_PASSWORD && count < 6 )); do
     REGISTRY_INFO=$(dagster-cloud serverless registry-info \
         --url "${DAGSTER_CLOUD_URL}/${INPUT_DEPLOYMENT}" \
         --api-token "$DAGSTER_CLOUD_API_TOKEN")
-    echo $REGISTRY_INFO > registry_info.env
-    source registry_info.env
+    # Parse KEY=VALUE pairs without `source` or unquoted `echo`, because
+    # either would re-expand any `$` in the value (e.g. Harbor robot
+    # usernames are `robot$<project>+push`) and mangle the credential.
+    AWS_ECR_USERNAME=""
+    AWS_ECR_PASSWORD=""
+    REGISTRY_URL=""
+    AWS_DEFAULT_REGION=""
+    CUSTOM_BASE_IMAGE_ALLOWED=""
+    while IFS='=' read -r _key _value; do
+        case "$_key" in
+            AWS_ECR_USERNAME) AWS_ECR_USERNAME="$_value" ;;
+            AWS_ECR_PASSWORD) AWS_ECR_PASSWORD="$_value" ;;
+            REGISTRY_URL) REGISTRY_URL="$_value" ;;
+            AWS_DEFAULT_REGION) AWS_DEFAULT_REGION="$_value" ;;
+            CUSTOM_BASE_IMAGE_ALLOWED) CUSTOM_BASE_IMAGE_ALLOWED="$_value" ;;
+        esac
+    done <<<"$REGISTRY_INFO"
     count=$(($count + 1))
     if [ ! -z "$AWS_ECR_PASSWORD" ]; then
         echo "Loaded registry information."


### PR DESCRIPTION
## Summary

When a serverless k8s (Harbor-backed) org runs through `serverless_prod_deploy` / `serverless_branch_deploy`, docker login fails with `401 unauthorized`. Two layers of bash variable expansion eat the `\$<project>` substring of the Harbor robot username `robot\$<project>+push`:

1. **`src/registry_info.sh`** — `echo \$REGISTRY_INFO > registry_info.env` (unquoted) followed by `source registry_info.env`. Both re-expand `\$<project>` (an unset shell variable) to empty before the value reaches `\$GITHUB_ENV`. Parse `KEY=VALUE` pairs via `read -r` instead so the literal `\$` survives.
2. **`Login to ECR` step** in both deploy action YAMLs — `\${{ env.AWS_ECR_USERNAME }}` template substitution pastes the value into the bash script _before_ bash runs. Switch to bash env-var access (`\"\$AWS_ECR_USERNAME\"`) so the value is read verbatim at run time.

ECR (`AWS` username, no `\$`) is unaffected. The fix is gated on Harbor robot accounts only — same code path, just no metacharacters to mangle.

## Test plan

Tested end-to-end on a real prod serverless v2 org (`devsuccess`) by pinning a downstream workflow to a branch with these changes and running:

- [x] Branch deployment via `serverless_branch_deploy` — green, image pushed to Harbor
- [x] Prod deployment via `serverless_prod_deploy` — green, image pushed to Harbor
- [x] Code location loaded in v2 deployment after image swap

Before the fix the rendered docker login command was:

```
docker login --username robot-<project>+push --password-stdin ...
```

After the fix:

```
docker login --username "\$AWS_ECR_USERNAME" --password-stdin "\$REGISTRY_URL"
```

with `AWS_ECR_USERNAME=robot\$<project>+push` arriving from the env intact.

## Follow-ups

- Once this merges and a `v1.12.18` (or backport) is cut, downstream repos can re-pin to the tag.