### PR TITLE
Give the generated image a working directory the runtime user owns

### DIFF
--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -13,7 +13,7 @@ RUN if [ -f "setup.py" ]; then \
         pip install .; \
     fi
 
-# Serverless v2 runs as a non-root user: the directory itself must be owned by that user
+# Serverless K8s runs as a non-root user: the directory itself must be owned by that user
 # (WORKDIR alone creates it root-owned), not just the files copied into it.
 RUN mkdir -p /opt/dagster/app && chown 65532:65532 /opt/dagster/app
 WORKDIR /opt/dagster/app

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -13,8 +13,11 @@ RUN if [ -f "setup.py" ]; then \
         pip install .; \
     fi
 
+# Serverless v2 runs as a non-root user: the directory itself must be owned by that user
+# (WORKDIR alone creates it root-owned), not just the files copied into it.
+RUN mkdir -p /opt/dagster/app && chown 65532:65532 /opt/dagster/app
 WORKDIR /opt/dagster/app
-COPY . /opt/dagster/app
+COPY --chown=65532:65532 . /opt/dagster/app
 
 # Install the rest of dependencies in case there is a requirements.txt
 RUN if [ -f "requirements.txt" ]; then \


### PR DESCRIPTION
## Summary & Motivation

Serverless K8s runs code location containers as a non-root user. The generated Dockerfile leaves `/opt/dagster/app` — which is also the `WORKDIR` — owned by root, so any user code writing to a relative path fails with `EACCES`. dbt writing a `target/` directory, a DuckDB file, or a plain `open("out.csv", "w")` all hit this. Classic serverless runs as root and is unaffected, which is why it has not surfaced before.

Both halves of the fix are needed. `COPY --chown` alone leaves the *directory* root-owned, because `WORKDIR` creates it before the copy — that produces a confusing partial failure where modifying an existing file works but creating a new one does not. Creating the directory with the right owner up front fixes the create case; `COPY --chown` fixes the modify case.

Neither costs image size: `COPY --chown` applies ownership as files are written rather than mutating them afterwards, so there is no layer copy-up, and the `mkdir` is an empty directory.

## Test Plan

Built the full generated Dockerfile (base image + template, with a stubbed `dagster-cloud` so the final version check passes) and ran it both ways:

- as the serverless K8s runtime uid — `cwd=/opt/dagster/app`, directory and copied files both owned by the runtime user, creating a new file succeeds, `mkdir target/` succeeds, source still readable
- as root — writes still succeed, so classic serverless is unchanged

Confirmed the failure mode first without the change: creating a new file returns `Permission denied` while appending to a copied file succeeds.

Not covered here: `dagster_cloud_post_install.sh` runs as root after the copy, so anything it creates in the app directory stays root-owned. A trailing `chown -R` would catch that, but it forces a copy-up of the whole directory, so it is worth doing only if it turns out to bite in practice. `sample-repo/Dockerfile` has the same shape and is left alone to keep this focused.

## Changelog

Code locations built by this action can write to their working directory when running on serverless K8s.